### PR TITLE
fix: SM-40 +storybook Alias 경로 추가 및 포매팅 

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,30 +1,38 @@
 const path = require('path');
 
 module.exports = {
-  "stories": [
-    "../src/**/*.stories.mdx",
-    "../src/**/*.stories.@(js|jsx|ts|tsx)"
-  ],
-  "webpackFinal": async (config) => {
-    config.resolve.alias["@base"] = path.resolve(__dirname, "../src/components/base");
-    config.resolve.alias["@components"] = path.resolve(__dirname, "../src/components");
-    config.resolve.alias["@hooks"] = path.resolve(__dirname, "../src/hooks");
-    config.resolve.alias["@utils"] = path.resolve(__dirname, "../src/utils");
-    config.resolve.alias["@"] = path.resolve(__dirname, "../src");
+  stories: ['../src/**/*.stories.mdx', '../src/**/*.stories.@(js|jsx|ts|tsx)'],
+  webpackFinal: async (config) => {
+    config.resolve.alias['@base'] = path.resolve(
+      __dirname,
+      '../src/components/base'
+    );
+    config.resolve.alias['@components'] = path.resolve(
+      __dirname,
+      '../src/components'
+    );
+    config.resolve.alias['@hooks'] = path.resolve(__dirname, '../src/hooks');
+    config.resolve.alias['@constants'] = path.resolve(
+      __dirname,
+      '../src/utils/constants'
+    );
+    config.resolve.alias['@utils'] = path.resolve(__dirname, '../src/utils');
+    config.resolve.alias['@'] = path.resolve(__dirname, '../src');
     return config;
   },
-  "typescript": {
+  typescript: {
     check: false,
     checkOptions: {},
     reactDocgen: 'react-docgen-typescript',
     reactDocgenTypescriptOptions: {
       shouldExtractLiteralValuesFromEnum: true,
-      propFilter: (prop) => (prop.parent ? !/node_modules/.test(prop.parent.fileName) : true),
-    },
+      propFilter: (prop) =>
+        prop.parent ? !/node_modules/.test(prop.parent.fileName) : true
+    }
   },
-  "addons": [
-    "@storybook/addon-links",
-    "@storybook/addon-essentials",
-    "@storybook/preset-create-react-app"
+  addons: [
+    '@storybook/addon-links',
+    '@storybook/addon-essentials',
+    '@storybook/preset-create-react-app'
   ]
-}
+};


### PR DESCRIPTION
## 📌 내용 설명
이전 merge에서 추가된 Alias 설정이 storybook 설정에서 미반영되어 추가반영합니다.
추가적으로 storybook의 main.js의 formatting 진행되었습니다.

## 👀 이미지 또는 Gif <!-- 구현한 내용의 동작을 담은 이미지, gif 등. 시각화된 내용이 없다면 생략 -->
![image](https://user-images.githubusercontent.com/75013334/144113812-0de4d470-629c-4155-bf78-1978b0424d9a.png)

## 📝 요구 사항 <!-- 구현한 내용의 세부 사항 목록과 완료 여부 체크 -->

## 💡 포인트 <!-- 구현한 내용 중 추가 설명, 강조가 필요한 핵심 로직이나 코드 설명. '특히 자세히 봐줬으면 좋겠다!'하는 내용들 -->

## 🚩 이슈 <!-- 해결하지 못한 내용 또는 부족한 점이 있어 추가 논의가 필요할 것 같은 부분에 대한 상세 설명 -->

## 🛠 피드백 반영 사항 <!-- 회의 또는 리뷰를 통해 발견하여 수정한 내역에 대한 설명-->

* 개발 환경 세팅관련 PR이므로 자체 merge 진행합니다.