### PR TITLE
fix: SM-75 컴포넌트 props type 수정 및 storybook 정리

### DIFF
--- a/src/components/base/Button/types.ts
+++ b/src/components/base/Button/types.ts
@@ -1,4 +1,4 @@
-import type { HTMLAttributes } from 'react';
+import type { ButtonHTMLAttributes } from 'react';
 import type { ColorKeys } from '@models/types';
 
 const BUTTON_SIZE = {
@@ -21,8 +21,7 @@ const BUTTON_SIZE = {
 } as const;
 type ButtonSizeKeys = keyof typeof BUTTON_SIZE;
 
-interface ButtonProps extends HTMLAttributes<HTMLButtonElement> {
-  type: 'button' | 'reset' | 'submit';
+interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   block?: boolean;
   size?: ButtonSizeKeys;
   dropShadow?: boolean;

--- a/src/components/base/Icon/types.ts
+++ b/src/components/base/Icon/types.ts
@@ -1,3 +1,5 @@
+import type { SVGAttributes } from 'react';
+
 const ICON_SIZE = {
   starFull: {
     width: '20px',
@@ -67,7 +69,7 @@ type IconType =
   | 'arrowRightWhite'
   | 'arrowLeftWhite'
   | 'back';
-interface IconProps {
+interface IconProps extends SVGAttributes<HTMLOrSVGElement> {
   type: IconType;
 }
 

--- a/src/components/base/Image/types.ts
+++ b/src/components/base/Image/types.ts
@@ -1,13 +1,11 @@
-import type { HTMLAttributes } from 'react';
+import type { ImgHTMLAttributes } from 'react';
 
 type ImageMode = 'cover' | 'fill' | 'contain';
 
-interface ImageProps extends HTMLAttributes<HTMLImageElement> {
+interface ImageProps extends ImgHTMLAttributes<HTMLImageElement> {
   lazy?: boolean;
-  src: string;
   width?: number | string;
   height?: number | string;
-  alt?: string;
   mode: ImageMode;
   block?: boolean;
   placeholder?: string;

--- a/src/components/base/Input/types.ts
+++ b/src/components/base/Input/types.ts
@@ -1,10 +1,9 @@
 import type { TextSizeKeys } from '@models';
-import type { HTMLAttributes } from 'react';
+import type { InputHTMLAttributes } from 'react';
 
-interface InputProps extends HTMLAttributes<HTMLInputElement> {
+interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
   inputType?: 'text' | 'number';
   fontSize?: TextSizeKeys;
-  maxLength?: number;
 }
 
 export type { InputProps };

--- a/src/components/base/index.ts
+++ b/src/components/base/index.ts
@@ -1,2 +1,8 @@
 export { default as Button } from '@base/Button';
 export { default as Text } from '@base/Text';
+export { default as Divider } from '@base/Divider';
+export { default as Icon } from '@base/Icon';
+export { default as Image } from '@base/Image';
+export { default as Input } from '@base/Input';
+export { default as Modal } from '@base/Modal';
+export { default as SectionDivider } from '@base/SectionDivider';

--- a/src/components/compound/ImageButton/types.ts
+++ b/src/components/compound/ImageButton/types.ts
@@ -4,7 +4,6 @@ import type { ImageMode } from '@base/Image/types';
 interface ImageButtonProps extends ButtonProps {
   src: string;
   mode?: ImageMode;
-  disabled?: boolean;
 }
 
 export type { ImageButtonProps };

--- a/src/components/compound/TextButton/types.ts
+++ b/src/components/compound/TextButton/types.ts
@@ -1,4 +1,4 @@
-import type { HTMLAttributes } from 'react';
+import type { ButtonProps } from '@base/Button/types';
 
 const TEXT_BUTTON = {
   SHORT_WHITE: {
@@ -57,7 +57,7 @@ const TEXT_BUTTON = {
 
 type TextButtonKeys = keyof typeof TEXT_BUTTON;
 
-interface TextButtonProps extends HTMLAttributes<HTMLButtonElement> {
+interface TextButtonProps extends ButtonProps {
   children: string;
   block?: boolean;
   buttonType: TextButtonKeys;

--- a/src/stories/base/Button.stories.tsx
+++ b/src/stories/base/Button.stories.tsx
@@ -3,7 +3,7 @@ import Button from '@base/Button';
 import type { ButtonProps } from '@base/Button/types';
 
 export default {
-  title: 'Component/Button',
+  title: 'Component/Base/Button',
   component: Button,
   argTypes: {
     type: {

--- a/src/stories/base/Icon.stories.tsx
+++ b/src/stories/base/Icon.stories.tsx
@@ -1,8 +1,8 @@
 import Icon from '@base/Icon';
 import styled from '@emotion/styled';
 import type { IconProps } from '@base/Icon/types';
-import { ICON_TYPE } from '@constants/icon';
 import type { ReactElement } from 'react';
+import { ICON_TYPES } from '@constants/icon';
 
 export default {
   title: 'Component/Base/Icon',
@@ -11,7 +11,7 @@ export default {
     type: {
       control: 'select',
       defaultValue: 'arrowDownNavy',
-      options: Object.keys(ICON_TYPE)
+      options: Object.keys(ICON_TYPES)
     }
   }
 };

--- a/src/stories/base/Image.stories.tsx
+++ b/src/stories/base/Image.stories.tsx
@@ -2,7 +2,7 @@ import Image from '@base/Image';
 import type { ReactElement } from 'react';
 
 export default {
-  title: 'Component/Image',
+  title: 'Component/Base/Image',
   component: Image
 };
 

--- a/src/stories/base/Modal.stories.tsx
+++ b/src/stories/base/Modal.stories.tsx
@@ -4,7 +4,7 @@ import Modal from '@base/Modal';
 import type { ModalProps } from '@base/Modal/types';
 
 export default {
-  title: 'Component/base/Modal',
+  title: 'Component/Base/Modal',
   component: Modal,
   argTypes: {
     size: {

--- a/src/stories/base/SectionDivider.stories.tsx
+++ b/src/stories/base/SectionDivider.stories.tsx
@@ -5,7 +5,7 @@ import styled from '@emotion/styled';
 import type { ReactElement } from 'react';
 
 export default {
-  title: 'Component/Base',
+  title: 'Component/Base/SectionDivider',
   component: SectionDivider,
   argTypes: {
     ratio: {

--- a/src/stories/compound/TextButton.stories.tsx
+++ b/src/stories/compound/TextButton.stories.tsx
@@ -3,7 +3,7 @@ import TextButton from '@components/compound/TextButton';
 import type { ReactElement } from 'react';
 
 export default {
-  title: 'Component/TextButton',
+  title: 'Component/Compound/TextButton',
   component: TextButton,
   argTypes: {
     block: {


### PR DESCRIPTION
## 📌 내용 설명 <!-- 구현한 내용의 핵심 요약 -->
컴포넌트들의 props extends 타입을 전반적으로 수정하고, storybook을 정리했습니다.
## 👀 이미지 또는 Gif <!-- 구현한 내용의 동작을 담은 이미지, gif 등. 시각화된 내용이 없다면 생략 -->
![image](https://user-images.githubusercontent.com/75013334/144989787-f3395745-b2f0-48d5-a9dc-bcd65a240447.png)
![image](https://user-images.githubusercontent.com/75013334/144989830-f85ae7c2-4cbb-4217-af6d-c6d3d2e58cde.png)
![image](https://user-images.githubusercontent.com/75013334/144989861-d9906bc9-4314-4f66-bcb5-696067b6af50.png)
![image](https://user-images.githubusercontent.com/75013334/144989901-94713267-43bf-429b-953f-ec0ed9d9006c.png)

## 📝 요구 사항 <!-- 구현한 내용의 세부 사항 목록과 완료 여부 체크 -->
기존의 HTMLAttributes<T> 에는 존재하지 않는 props 를 부여하기 위해 조금더 확장된 타입을 부여하였습니다.
예를들어, ButtonHTMLAttributes<T>는 HTMLAttributes<T>로부터 확장(extends) 받아와, 추가적인 button이 가지는 prop type들을 추가해놓은 타입입니다.
![image](https://user-images.githubusercontent.com/75013334/144990317-023ca148-9f44-401b-b952-4678ff83a95f.png)
이와 같이, disabled 또는 type과 같이 Button의 고유한 속성들에 대해서 따로 타입명시를 하지 않아도, 사용가능하게 됩니다 ( ...props 를 부여한다는 전재하에)
## 💡 포인트 <!-- 구현한 내용 중 추가 설명, 강조가 필요한 핵심 로직이나 코드 설명. '특히 자세히 봐줬으면 좋겠다!'하는 내용들 -->

## 🚩 이슈 <!-- 해결하지 못한 내용 또는 부족한 점이 있어 추가 논의가 필요할 것 같은 부분에 대한 상세 설명 -->

## 🛠 피드백 반영 사항 <!-- 회의 또는 리뷰를 통해 발견하여 수정한 내역에 대한 설명-->
