### PR TITLE
fix: SM-79 컴포넌트 Style 재정의

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -64,6 +64,7 @@ module.exports = {
       }
     ],
     '@typescript-eslint/no-unused-expressions': 'error',
-    '@typescript-eslint/no-duplicate-imports': 'error'
+    '@typescript-eslint/no-duplicate-imports': 'error',
+    '@typescript-eslint/jsx-key': 'off'
   }
 };

--- a/src/components/base/Button/types.ts
+++ b/src/components/base/Button/types.ts
@@ -3,12 +3,12 @@ import type { ColorKeys } from '@models/types';
 
 const BUTTON_SIZE = {
   short: {
-    width: '180px',
-    height: '52px'
+    width: '90px',
+    height: '30px'
   },
   long: {
-    width: '366px',
-    height: '48px'
+    width: '220px',
+    height: '30px'
   },
   kakao: {
     width: '300px',

--- a/src/components/base/Input/index.tsx
+++ b/src/components/base/Input/index.tsx
@@ -6,7 +6,7 @@ const DEFAULT_MAXLENGTH = 20;
 
 const Input = ({
   inputType = 'text',
-  fontSize = 'md',
+  fontSize = 'xs',
   maxLength = DEFAULT_MAXLENGTH,
   ...props
 }: InputProps): ReactElement => {

--- a/src/components/base/Input/style.tsx
+++ b/src/components/base/Input/style.tsx
@@ -1,16 +1,20 @@
 import styled from '@emotion/styled';
 import type { InputProps } from './types';
 
-import { TEXT_SIZE } from '@utils/constants';
+import { COLOR, TEXT_SIZE } from '@utils/constants';
 
 const StyledInput = styled.input<Required<Pick<InputProps, 'fontSize'>>>`
   font-size: ${({ fontSize }): string => TEXT_SIZE[fontSize]};
-  border-radius: 1rem;
-  width: 393px;
-  height: 52px;
-  background: #eae4e4;
-  box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
+  width: 200px;
+  height: 30px;
+  background: ${COLOR.BASIC_WHITE};
+  box-shadow: 0px 1.5px 4px rgba(0, 0, 0, 0.25);
   border-radius: 7px;
+  border: none;
+
+  &:focus {
+    outline: 1px solid ${COLOR.LIGHT_PINK};
+  }
 `;
 
 export { StyledInput };

--- a/src/components/base/Modal/styled.ts
+++ b/src/components/base/Modal/styled.ts
@@ -22,6 +22,9 @@ const StyledModalContainer = styled.div<ContainerProps>`
   width: ${({ size }): string => MODAL_SIZE[size].width};
   height: ${({ size }): string => MODAL_SIZE[size].height};
   background-color: ${({ color }): string => COLOR[color]};
+  border-radius: 12px;
+  padding: 5px;
+  box-sizing: border-box;
 `;
 
 export { StyledModalBackground, StyledModalContainer };

--- a/src/components/base/Modal/types.ts
+++ b/src/components/base/Modal/types.ts
@@ -3,16 +3,16 @@ import type { ColorKeys } from '@models/types';
 
 const MODAL_SIZE = {
   sm: {
-    width: '574px',
-    height: '668px'
+    width: '320px',
+    height: '360px'
   },
   md: {
-    width: '891px',
-    height: '668px'
+    width: '680px',
+    height: '480px'
   },
   lg: {
-    width: '1080px',
-    height: '840px'
+    width: '1040px',
+    height: '640px'
   }
 } as const;
 type ModalSizeKeys = keyof typeof MODAL_SIZE;

--- a/src/components/compound/TextButton/types.ts
+++ b/src/components/compound/TextButton/types.ts
@@ -10,7 +10,7 @@ const TEXT_BUTTON = {
       clickedColor: 'BASIC_PINK'
     },
     textProps: {
-      size: 'sm',
+      size: 'xs',
       color: 'BLACK'
     }
   },
@@ -23,7 +23,7 @@ const TEXT_BUTTON = {
       clickedColor: 'STRONG_PINK'
     },
     textProps: {
-      size: 'sm',
+      size: 'xs',
       color: 'BASIC_WHITE'
     }
   },
@@ -36,7 +36,7 @@ const TEXT_BUTTON = {
       clickedColor: 'BASIC_PINK'
     },
     textProps: {
-      size: 'md',
+      size: 'xs',
       color: 'BLACK'
     }
   },
@@ -49,7 +49,7 @@ const TEXT_BUTTON = {
       clickedColor: 'STRONG_PINK'
     },
     textProps: {
-      size: 'md',
+      size: 'xs',
       color: 'BASIC_WHITE'
     }
   }

--- a/src/utils/constants/text.ts
+++ b/src/utils/constants/text.ts
@@ -1,4 +1,5 @@
 const TEXT_SIZE = {
+  xxs: '0.5rem',
   xs: '1rem',
   sm: '1.5rem',
   md: '2rem',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,10 @@
   "extends": "./tsconfig.path.json",
   "compilerOptions": {
     "target": "es5",
-    "lib": ["dom", "dom.iterable"],
+    "lib": [
+      "dom",
+      "dom.iterable"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
@@ -17,5 +20,8 @@
     "jsx": "react-jsx",
     "module": "esnext"
   },
-  "include": ["src", "craco.config.js"]
+  "include": [
+    "src",
+    "craco.config.js"
+  ]
 }


### PR DESCRIPTION
## 📌 내용 설명 <!-- 구현한 내용의 핵심 요약 -->
기존의 컴포넌트들의 사이즈들이 크다고 판단되어 맥북 화면에 사이즈 기준으로 조정을 진행했습니다. 
## 👀 이미지 또는 Gif <!-- 구현한 내용의 동작을 담은 이미지, gif 등. 시각화된 내용이 없다면 생략 -->
![화면 기록 2021-12-07 오후 10 16 16](https://user-images.githubusercontent.com/75013334/145036388-01da85b0-6c41-48df-9222-95c58ff38ed3.gif)

## 📝 요구 사항 <!-- 구현한 내용의 세부 사항 목록과 완료 여부 체크 -->

## 💡 포인트 <!-- 구현한 내용 중 추가 설명, 강조가 필요한 핵심 로직이나 코드 설명. '특히 자세히 봐줬으면 좋겠다!'하는 내용들 -->
Text 컴포넌트의 사이즈로 xxs를 추가하였습니다!
## 🚩 이슈 <!-- 해결하지 못한 내용 또는 부족한 점이 있어 추가 논의가 필요할 것 같은 부분에 대한 상세 설명 -->

## 🛠 피드백 반영 사항 <!-- 회의 또는 리뷰를 통해 발견하여 수정한 내역에 대한 설명-->
