### PR TITLE
Feat: SM-56 Album 컴포넌트

### DIFF
--- a/src/components/compound/Album/index.tsx
+++ b/src/components/compound/Album/index.tsx
@@ -5,7 +5,7 @@ import Image from '@base/Image';
 import { StyledContainer } from './styled';
 
 const DEFAULT_TYPE = 'alcohol';
-const DEFAULT_TEXT = 'mojito';
+const DEFAULT_TEXT = '';
 const DEFAULT_IMAGE_WIDTH = '70px';
 const DEFAULT_IMAGE_HEIGHT = '70px';
 const DEFAULT_IMAGE_SRC = 'http://via.placeholder.com/100x100';

--- a/src/components/compound/Album/index.tsx
+++ b/src/components/compound/Album/index.tsx
@@ -1,0 +1,25 @@
+import type { ReactElement } from 'react';
+import type { AlbumProps } from './types';
+import Text from '@base/Text';
+import { StyledContainer } from './styled';
+
+const DEFAULT_TYPE = 'alcohol';
+const DEFAULT_TEXT = 'mojito';
+const DEFAULT_IMAGE_SRC = 'http://via.placeholder.com/50x50';
+
+const Album = ({
+  type = DEFAULT_TYPE,
+  text = DEFAULT_TEXT,
+  imageSrc = DEFAULT_IMAGE_SRC
+}: AlbumProps): ReactElement => {
+  return (
+    <StyledContainer type={type}>
+      <img src={imageSrc} style={{ margin: '20px 0px' }} />
+      <Text color='BLACK' size='xs'>
+        {text}
+      </Text>
+    </StyledContainer>
+  );
+};
+
+export default Album;

--- a/src/components/compound/Album/index.tsx
+++ b/src/components/compound/Album/index.tsx
@@ -1,20 +1,30 @@
 import type { ReactElement } from 'react';
 import type { AlbumProps } from './types';
 import Text from '@base/Text';
+import Image from '@base/Image';
 import { StyledContainer } from './styled';
 
 const DEFAULT_TYPE = 'alcohol';
 const DEFAULT_TEXT = 'mojito';
-const DEFAULT_IMAGE_SRC = 'http://via.placeholder.com/50x50';
+const DEFAULT_IMAGE_WIDTH = '70px';
+const DEFAULT_IMAGE_HEIGHT = '70px';
+const DEFAULT_IMAGE_SRC = 'http://via.placeholder.com/100x100';
 
 const Album = ({
   type = DEFAULT_TYPE,
   text = DEFAULT_TEXT,
+  imageWidth = DEFAULT_IMAGE_WIDTH,
+  imageHeight = DEFAULT_IMAGE_HEIGHT,
   imageSrc = DEFAULT_IMAGE_SRC
 }: AlbumProps): ReactElement => {
   return (
     <StyledContainer type={type}>
-      <img src={imageSrc} style={{ margin: '20px 0px' }} />
+      <Image
+        height={imageHeight}
+        mode='cover'
+        src={imageSrc}
+        width={imageWidth}
+      />
       <Text color='BLACK' size='xs'>
         {text}
       </Text>

--- a/src/components/compound/Album/styled.ts
+++ b/src/components/compound/Album/styled.ts
@@ -1,0 +1,20 @@
+import styled from '@emotion/styled';
+import type { AlbumProps } from './types';
+import { ALBUM_ATTRIBUTES } from './types';
+
+const StyledContainer = styled.div<Required<Pick<AlbumProps, 'type'>>>`
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+  background-color: #ffffff;
+  box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19);
+  margin: 10px 20px;
+  width: ${({ type }): string => ALBUM_ATTRIBUTES[type].width};
+  height: ${({ type }): string => ALBUM_ATTRIBUTES[type].height};
+  border: 2px solid #ffffff;
+  border-radius: ${({ type }): string =>
+    ALBUM_ATTRIBUTES[type].shape === 'circle' ? '50%' : '20%'};
+`;
+
+export { StyledContainer };

--- a/src/components/compound/Album/styled.ts
+++ b/src/components/compound/Album/styled.ts
@@ -7,6 +7,7 @@ const StyledContainer = styled.div<Required<Pick<AlbumProps, 'type'>>>`
   justify-content: center;
   align-items: center;
   flex-direction: column;
+  gap: 5px;
   background-color: #ffffff;
   box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19);
   margin: 10px 20px;

--- a/src/components/compound/Album/styled.ts
+++ b/src/components/compound/Album/styled.ts
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled';
 import type { AlbumProps } from './types';
 import { ALBUM_ATTRIBUTES } from './types';
+import { COLOR } from '@utils/constants/colors';
 
 const StyledContainer = styled.div<Required<Pick<AlbumProps, 'type'>>>`
   display: inline-flex;
@@ -8,12 +9,12 @@ const StyledContainer = styled.div<Required<Pick<AlbumProps, 'type'>>>`
   align-items: center;
   flex-direction: column;
   gap: 5px;
-  background-color: #ffffff;
+  background-color: ${COLOR.BASIC_WHITE};
   box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19);
   margin: 10px 20px;
   width: ${({ type }): string => ALBUM_ATTRIBUTES[type].width};
   height: ${({ type }): string => ALBUM_ATTRIBUTES[type].height};
-  border: 2px solid #ffffff;
+  border: 2px solid ${COLOR.BASIC_WHITE};
   border-radius: ${({ type }): string =>
     ALBUM_ATTRIBUTES[type].shape === 'circle' ? '50%' : '20%'};
 `;

--- a/src/components/compound/Album/types.ts
+++ b/src/components/compound/Album/types.ts
@@ -1,0 +1,28 @@
+const ALBUM_ATTRIBUTES = {
+  alcohol: {
+    width: '130px',
+    height: '130px',
+    shape: 'circle'
+  },
+  sweetener: {
+    width: '130px',
+    height: '130px',
+    shape: 'round'
+  },
+  result: {
+    width: '130px',
+    height: '150px',
+    shape: 'round'
+  }
+} as const;
+
+type AlbumAttributeKeys = keyof typeof ALBUM_ATTRIBUTES;
+
+interface AlbumProps {
+  type?: AlbumAttributeKeys;
+  text?: string;
+  imageSrc?: string;
+}
+
+export type { AlbumProps };
+export { ALBUM_ATTRIBUTES };

--- a/src/components/compound/Album/types.ts
+++ b/src/components/compound/Album/types.ts
@@ -21,6 +21,8 @@ type AlbumAttributeKeys = keyof typeof ALBUM_ATTRIBUTES;
 interface AlbumProps {
   type?: AlbumAttributeKeys;
   text?: string;
+  imageWidth?: string;
+  imageHeight?: string;
   imageSrc?: string;
 }
 

--- a/src/stories/compound/Album.stories.tsx
+++ b/src/stories/compound/Album.stories.tsx
@@ -1,0 +1,46 @@
+import Album from '@components/compound/Album';
+import type { AlbumProps } from '@components/compound/Album/types';
+import { ALBUM_ATTRIBUTES } from '@components/compound/Album/types';
+import styled from '@emotion/styled';
+import type { ReactElement } from 'react';
+
+export default {
+  title: 'Component/Compound/Album',
+  component: Album,
+  argTypes: {
+    type: {
+      control: 'select',
+      options: Object.keys(ALBUM_ATTRIBUTES)
+    },
+    text: {
+      control: 'text',
+      defaultValue: 'mojito'
+    },
+    imageWidth: {
+      control: 'number',
+      defaultValue: 70
+    },
+    imageHeight: {
+      control: 'number',
+      defaultValue: 70
+    },
+    imageSrc: {
+      control: 'text',
+      defaultValue: 'http://via.placeholder.com/100x100'
+    }
+  }
+};
+
+const Container = styled.div`
+  width: auto;
+  height: 100%;
+  background-color: #f0efe3;
+`;
+
+export const Default = (props: AlbumProps): ReactElement => {
+  return (
+    <Container>
+      <Album {...props} />
+    </Container>
+  );
+};


### PR DESCRIPTION
## 📌 내용 설명 <!-- 구현한 내용의 핵심 요약 -->
Album compound 컴포넌트를 구현하였습니다.

## 👀 이미지 또는 Gif <!-- 구현한 내용의 동작을 담은 이미지, gif 등. 시각화된 내용이 없다면 생략 -->
![ezgif-6-3fab29d08df3](https://user-images.githubusercontent.com/48900550/145168880-d7fa3e0c-7f43-41a7-9066-a90365f1ee2b.gif)

## 📝 요구 사항 <!-- 구현한 내용의 세부 사항 목록과 완료 여부 체크 -->
앨범 컴포넌트는 크게 2가지의 하위 컴포넌트를 갖습니다. 
- 1. 이미지 컴포넌트
- 2. 텍스트 컴포넌트
따라서 앨범 컴포넌트는 이미지에 대한 width, height, src 값을 props로 받고
텍스트에 대한 text 값을 props로 받습니다. 
마지막으로 재료의 종류에 따라서 앨범의 크기와 모양을 가변적으로 변경할 수 있도록
type props를 받습니다. type은 총 3가지, alcohol, sweetener, result를 받습니다.

## 💡 포인트 <!-- 구현한 내용 중 추가 설명, 강조가 필요한 핵심 로직이나 코드 설명. '특히 자세히 봐줬으면 좋겠다!'하는 내용들 -->
컨벤션이나 다른 수정 사항이 있다면 말씀해주세요! 

## 🚩 이슈 <!-- 해결하지 못한 내용 또는 부족한 점이 있어 추가 논의가 필요할 것 같은 부분에 대한 상세 설명 -->

## 🛠 피드백 반영 사항 <!-- 회의 또는 리뷰를 통해 발견하여 수정한 내역에 대한 설명-->
