### PR TITLE
feat: SM-83 TitleSectionContainer 컴포넌트 구현

### DIFF
--- a/src/components/domain/TitleSectionContainer/index.tsx
+++ b/src/components/domain/TitleSectionContainer/index.tsx
@@ -1,0 +1,35 @@
+import type { ReactElement } from 'react';
+import Text from '@base/Text';
+import { StyledContainer, StyledLine } from './styled';
+import type { TitleSectionContainerProps } from './types';
+
+const TitleSectionContainer = ({
+  children,
+  titleText = '',
+  titleSize = 'md',
+  titleColor = 'BLACK',
+  bold,
+  dividerVisible = false,
+  dividerColor = 'DARK_GRAY',
+  dividerWidth = '200px',
+  dividerThickness = '1px',
+  gap = '5px'
+}: TitleSectionContainerProps): ReactElement => {
+  return (
+    <StyledContainer>
+      <Text bold={bold} color={titleColor} size={titleSize}>
+        {titleText}
+      </Text>
+      <StyledLine
+        color={dividerColor}
+        gap={gap}
+        height={dividerThickness}
+        visible={dividerVisible}
+        width={dividerWidth}
+      />
+      {children}
+    </StyledContainer>
+  );
+};
+
+export default TitleSectionContainer;

--- a/src/components/domain/TitleSectionContainer/styled.ts
+++ b/src/components/domain/TitleSectionContainer/styled.ts
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
-import type { ColorKeys } from '@models';
 import { COLOR } from '@constants/colors';
+import type { StyledLineProps } from './types';
 
 const StyledContainer = styled.div`
   display: flex;
@@ -8,14 +8,6 @@ const StyledContainer = styled.div`
   align-items: center;
   justify-content: center;
 `;
-
-interface StyledLineProps {
-  visible?: boolean;
-  width?: string | number;
-  height?: string | number;
-  gap?: string | number;
-  color: ColorKeys;
-}
 
 const StyledLine = styled.hr<StyledLineProps>`
   display: block;

--- a/src/components/domain/TitleSectionContainer/styled.ts
+++ b/src/components/domain/TitleSectionContainer/styled.ts
@@ -1,0 +1,34 @@
+import styled from '@emotion/styled';
+import type { ColorKeys } from '@models';
+import { COLOR } from '@constants/colors';
+
+const StyledContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+`;
+
+interface StyledLineProps {
+  visible?: boolean;
+  width?: string | number;
+  height?: string | number;
+  gap?: string | number;
+  color: ColorKeys;
+}
+
+const StyledLine = styled.hr<StyledLineProps>`
+  display: block;
+  border: none;
+  visibility: ${({ visible }): string => (visible ? 'visible' : 'hidden')};
+  width: ${({ width }): string =>
+    width ? (typeof width === 'string' ? width : `${width}px`) : '100px'};
+  height: ${({ height }): string =>
+    height ? (typeof height === 'string' ? height : `${height}px`) : '1px'};
+  background-color: ${({ color }): string =>
+    color ? COLOR[color] : COLOR['DARK_GRAY']};
+  margin: ${({ gap }): string =>
+    gap ? (typeof gap === 'string' ? `${gap} 0` : `${gap}px 0`) : '5px 0'};
+`;
+
+export { StyledContainer, StyledLine };

--- a/src/components/domain/TitleSectionContainer/types.ts
+++ b/src/components/domain/TitleSectionContainer/types.ts
@@ -1,0 +1,17 @@
+import type { HTMLAttributes, ReactChild } from 'react';
+import type { TextSizeKeys, ColorKeys } from '@models/types';
+
+interface TitleSectionContainerProps extends HTMLAttributes<HTMLDivElement> {
+  titleText?: string;
+  titleSize?: TextSizeKeys;
+  titleColor?: ColorKeys;
+  bold?: boolean;
+  dividerVisible?: boolean;
+  dividerColor: ColorKeys;
+  dividerWidth: string;
+  dividerThickness?: string;
+  gap?: string | number;
+  content: ReactChild[];
+}
+
+export type { TitleSectionContainerProps };

--- a/src/components/domain/TitleSectionContainer/types.ts
+++ b/src/components/domain/TitleSectionContainer/types.ts
@@ -1,4 +1,4 @@
-import type { HTMLAttributes, ReactChild } from 'react';
+import type { HTMLAttributes } from 'react';
 import type { TextSizeKeys, ColorKeys } from '@models/types';
 
 interface TitleSectionContainerProps extends HTMLAttributes<HTMLDivElement> {
@@ -11,7 +11,6 @@ interface TitleSectionContainerProps extends HTMLAttributes<HTMLDivElement> {
   dividerWidth: string;
   dividerThickness?: string;
   gap?: string | number;
-  content: ReactChild[];
 }
 
 export type { TitleSectionContainerProps };

--- a/src/stories/compound/TextButton.stories.tsx
+++ b/src/stories/compound/TextButton.stories.tsx
@@ -11,7 +11,7 @@ export default {
     },
     buttonType: {
       control: 'inline-radio',
-      oprtions: ['SHORT_WHITE', 'SHORT_PINK', 'LONG_WHITE', 'LONG_PINK']
+      options: ['SHORT_WHITE', 'SHORT_PINK', 'LONG_WHITE', 'LONG_PINK']
     },
     children: {
       control: 'text'

--- a/src/stories/domain/TitleSectionContainer.stories.tsx
+++ b/src/stories/domain/TitleSectionContainer.stories.tsx
@@ -1,0 +1,58 @@
+import TitleSectionContainer from '@domain/TitleSectionContainer';
+import type { ReactElement } from 'react';
+import type { TitleSectionContainerProps } from '@components/domain/TitleSectionContainer/types';
+
+export default {
+  title: 'Component/domain/TitleSectionContainer',
+  component: TitleSectionContainer,
+  argTypes: {
+    titleText: {
+      control: 'text'
+    },
+    dividerVisible: {
+      control: 'boolean'
+    },
+    dividerColor: {
+      control: 'select',
+      options: [
+        undefined,
+        'BASIC_WHITE',
+        'LIGHT_GRAY',
+        'DARK_GRAY',
+        'BLACK',
+        'LIGHT_PINK',
+        'BASIC_PINK',
+        'MIDDLE_PINK',
+        'STRONG_PINK',
+        'NAVY',
+        'ORANGE',
+        'VIOLET',
+        'IVORY',
+        'LIGHT_YELLOW',
+        'DARK_YELLOW',
+        'BLUE',
+        'GREEN'
+      ]
+    },
+    dividerWidth: {
+      control: 'number'
+    },
+    dividerThickness: {
+      control: 'number'
+    },
+    gap: {
+      control: 'number'
+    },
+    bold: {
+      control: 'boolean'
+    }
+  }
+};
+
+export const Defatult = (props: TitleSectionContainerProps): ReactElement => {
+  return (
+    <TitleSectionContainer {...props}>
+      <div>내용물입니다</div>
+    </TitleSectionContainer>
+  );
+};


### PR DESCRIPTION
## 📌 내용 설명 <!-- 구현한 내용의 핵심 요약 -->
제목이 있는 콘텐츠 컨테이너.
자식으로 다른 컴포넌트를 넣고, 제목을 입력한 뒤 간격이나 구분선 등을 조작할 수 있다.
## 👀 이미지 또는 Gif <!-- 구현한 내용의 동작을 담은 이미지, gif 등. 시각화된 내용이 없다면 생략 -->
![Dec-08-2021 18-03-03](https://user-images.githubusercontent.com/75300807/145181349-c31a51e0-a128-45c6-9cca-559a4c02c9e5.gif)
## 📝 요구 사항 <!-- 구현한 내용의 세부 사항 목록과 완료 여부 체크 -->
+ children: 콘텐츠 영역에 들어갈 컴포넌트나 스트링 등을 받습니다.
+ titleText, titleSize, titleColor, bold: 제목 영역에 해당되는 문자열과 스타일 값을 받습니다.
+ divider ~: 구분선을 보이게 할지, 굵기나 길이를 어떻게 해야할지에 해당하는 값을 받습니다.
+ gap: 구분선으 기준으로 제목과 콘텐츠 사이의 간격을 받습니다.
## 💡 포인트 <!-- 구현한 내용 중 추가 설명, 강조가 필요한 핵심 로직이나 코드 설명. '특히 자세히 봐줬으면 좋겠다!'하는 내용들 -->
+ TitleSectionContainer에서 위의 props를 받은 뒤에, 내부적으로 Text, StyledLine 컴포넌트에 각각의 값을 전달해줍니다.
## 🚩 이슈 <!-- 해결하지 못한 내용 또는 부족한 점이 있어 추가 논의가 필요할 것 같은 부분에 대한 상세 설명 -->
+ 구분선 같은 경우는 특정 값을 미리 지정해두지 않았고 직접 값을 줘야합니다. 타이틀의 크기가 길이에 따라서 달라질 것 같아서..
## 🛠 피드백 반영 사항 <!-- 회의 또는 리뷰를 통해 발견하여 수정한 내역에 대한 설명-->
