### PR TITLE
feat: SM-157 nickname 중복 검사기능 추가

### DIFF
--- a/src/components/base/Button/types.ts
+++ b/src/components/base/Button/types.ts
@@ -21,6 +21,10 @@ const BUTTON_SIZE = {
   headerIcon: {
     width: '50px',
     height: '50px'
+  },
+  xShort: {
+    width: '50px',
+    height: '20px'
   }
 } as const;
 type ButtonSizeKeys = keyof typeof BUTTON_SIZE;

--- a/src/components/compound/TextButton/types.ts
+++ b/src/components/compound/TextButton/types.ts
@@ -52,6 +52,19 @@ const TEXT_BUTTON = {
       size: 'xs',
       color: 'BASIC_WHITE'
     }
+  },
+  X_SHORT_WHITE: {
+    buttonProps: {
+      type: 'button',
+      size: 'xShort',
+      basicColor: 'BASIC_WHITE',
+      hoverColor: 'LIGHT_PINK',
+      clickedColor: 'BASIC_PINK'
+    },
+    textProps: {
+      size: 'xxxs',
+      color: 'BLACK'
+    }
   }
 } as const;
 

--- a/src/components/compound/UserInput/index.tsx
+++ b/src/components/compound/UserInput/index.tsx
@@ -1,3 +1,4 @@
+import { request } from '@apis/config';
 import { Text } from '@base';
 import Input from '@base/Input';
 import type { InputProps } from '@base/Input/types';
@@ -5,17 +6,87 @@ import Select from '@base/Select';
 import type { SelectProps } from '@base/Select/types';
 import { USER_FORM_LABEL_TEXT, USER_GENDER, USER_MBTI } from '@constants';
 import type { ReactElement } from 'react';
-import { StyledErrorContainer, StyledLabel } from './styled';
+import { useCallback, useState, useEffect } from 'react';
+import {
+  StyledCheckButton,
+  StyledErrorContainer,
+  StyledLabel,
+  StyledNicknameInputContainer
+} from './styled';
 import type { UserInputProps } from './types';
+
+interface IcheckNicknameAPIState {
+  value: boolean | null;
+  isLoading: boolean;
+  error: string | null;
+}
+
+const RADIX_TEN = 10;
 
 const UserInput = ({
   inputType,
   formType,
   errorMessage,
   value,
+  onNicknameChecked,
   ...props
 }: UserInputProps & (InputProps | SelectProps)): ReactElement => {
   let inputEl;
+
+  const [checkNicknameAPIState, setCheckNicknameAPIState] =
+    useState<IcheckNicknameAPIState>({
+      value: null,
+      isLoading: false,
+      error: null
+    });
+
+  const getVerifyNickname = async (nickname: string): Promise<void> => {
+    try {
+      setCheckNicknameAPIState((prevState) => ({
+        ...prevState,
+        isLoading: true
+      }));
+      const { data } = await request.get<any, { data: { can: boolean } }>(
+        `/user/nickname/${nickname}`
+      );
+      if (data.can) {
+        onNicknameChecked?.(true);
+        setCheckNicknameAPIState({
+          value: true,
+          isLoading: false,
+          error: null
+        });
+      } else {
+        onNicknameChecked?.(false);
+        setCheckNicknameAPIState({
+          value: false,
+          isLoading: false,
+          error: '사용중인 이름입니다'
+        });
+      }
+    } catch (e) {
+      console.error(e);
+      setCheckNicknameAPIState((prevValue) => ({
+        ...prevValue,
+        isLoading: false,
+        error: '알수없는 에러입니다. 잠시 후에 다시 시도해주세요.'
+      }));
+    }
+  };
+
+  // value 바뀔시 중복검사 상태 초기화
+  useEffect(() => {
+    onNicknameChecked?.(false);
+    setCheckNicknameAPIState({
+      value: null,
+      isLoading: false,
+      error: null
+    });
+  }, [value]);
+
+  const handleCheckNickname = useCallback(() => {
+    value && getVerifyNickname(value.toString(RADIX_TEN));
+  }, [value, getVerifyNickname]);
 
   switch (inputType) {
     case 'age':
@@ -30,12 +101,34 @@ const UserInput = ({
       break;
     case 'nickname':
       inputEl = (
-        <Input
-          inputType='text'
-          name='nickname'
-          value={value || ''}
-          {...(props as InputProps)}
-        />
+        <StyledNicknameInputContainer>
+          <Input
+            inputType='text'
+            name='nickname'
+            value={value || ''}
+            {...(props as InputProps)}
+          />
+          {value && !errorMessage && (
+            <StyledCheckButton
+              color={checkNicknameAPIState.value ? 'GREEN' : 'MIDDLE_PINK'}
+              disabled={
+                checkNicknameAPIState.isLoading || !!checkNicknameAPIState.value
+              }
+              type='button'
+              onClick={handleCheckNickname}
+            >
+              {checkNicknameAPIState.isLoading ? (
+                <Text bold size='xxxs'>
+                  체크 중...
+                </Text>
+              ) : (
+                <Text bold size='xxxs'>
+                  {checkNicknameAPIState.value ? '사용 가능' : '중복 검사'}
+                </Text>
+              )}
+            </StyledCheckButton>
+          )}
+        </StyledNicknameInputContainer>
       );
       break;
     case 'gender':
@@ -69,7 +162,7 @@ const UserInput = ({
       {inputEl}
       <StyledErrorContainer>
         <Text color='STRONG_PINK' size='xxxs'>
-          {errorMessage}
+          {checkNicknameAPIState.error || errorMessage}
         </Text>
       </StyledErrorContainer>
     </StyledLabel>

--- a/src/components/compound/UserInput/index.tsx
+++ b/src/components/compound/UserInput/index.tsx
@@ -117,15 +117,13 @@ const UserInput = ({
               type='button'
               onClick={handleCheckNickname}
             >
-              {checkNicknameAPIState.isLoading ? (
-                <Text bold size='xxxs'>
-                  체크 중...
-                </Text>
-              ) : (
-                <Text bold size='xxxs'>
-                  {checkNicknameAPIState.value ? '사용 가능' : '중복 검사'}
-                </Text>
-              )}
+              <Text bold color='BASIC_WHITE' size='xxxs'>
+                {checkNicknameAPIState.isLoading
+                  ? '체크 중...'
+                  : checkNicknameAPIState.value
+                  ? '사용 가능'
+                  : '중복 검사'}
+              </Text>
             </StyledCheckButton>
           )}
         </StyledNicknameInputContainer>

--- a/src/components/compound/UserInput/styled.ts
+++ b/src/components/compound/UserInput/styled.ts
@@ -1,4 +1,6 @@
+import { COLOR } from '@constants';
 import styled from '@emotion/styled';
+import type { ColorKeys } from '@models';
 
 const StyledLabel = styled.label`
   display: flex;
@@ -17,4 +19,39 @@ const StyledErrorContainer = styled.div`
   height: 15px;
 `;
 
-export { StyledLabel, StyledErrorContainer };
+const StyledNicknameInputContainer = styled.div`
+  position: relative;
+`;
+
+const StyledCheckButton = styled.button<{ color: ColorKeys }>`
+  position: absolute;
+  top: 50%;
+  right: 0;
+  transform: translate(0, -50%);
+  padding: 5px 3px;
+  border: none;
+  background-color: ${({ color }): string => COLOR[color]};
+  border-radius: 3px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  transition: 0.2s ease-in-out;
+
+  &:hover:not(:disabled) {
+    filter: brightness(0.9);
+  }
+
+  &:active:not(:disabled) {
+    transform: translate(0, -40%);
+  }
+  &:disabled {
+    cursor: default;
+  }
+`;
+
+export {
+  StyledLabel,
+  StyledErrorContainer,
+  StyledNicknameInputContainer,
+  StyledCheckButton
+};

--- a/src/components/compound/UserInput/styled.ts
+++ b/src/components/compound/UserInput/styled.ts
@@ -26,7 +26,7 @@ const StyledNicknameInputContainer = styled.div`
 const StyledCheckButton = styled.button<{ color: ColorKeys }>`
   position: absolute;
   top: 50%;
-  right: 0;
+  right: 2px;
   transform: translate(0, -50%);
   padding: 5px 3px;
   border: none;

--- a/src/components/compound/UserInput/types.ts
+++ b/src/components/compound/UserInput/types.ts
@@ -4,6 +4,7 @@ interface UserInputProps {
   inputType: IUserInputType;
   formType: IUserFormType;
   errorMessage?: string;
+  onNicknameChecked?(value: boolean): void;
 }
 
 export type { UserInputProps };

--- a/src/components/domain/RegisterModal/index.tsx
+++ b/src/components/domain/RegisterModal/index.tsx
@@ -28,12 +28,6 @@ const RegisterModal = ({
           />
         </IdentifierContainer>
         <UserForm
-          initialValues={{
-            nickname: null,
-            gender: null,
-            age: null,
-            mbti: null
-          }}
           type='Register'
           onSubmit={onSubmit}
           onValidatedValuesChanged={(value): void => {

--- a/src/components/domain/SectionDividerWithTitle/index.tsx
+++ b/src/components/domain/SectionDividerWithTitle/index.tsx
@@ -22,11 +22,13 @@ const SectionDividerWithTitle = ({
   withHeader = false,
   ...props
 }: SectionDividerWithTitleProps): ReactElement => {
-  const wrappedChildren = Children.toArray(children).map((element) => (
-    <StyledSectionDividerContent alignItems={alignItems}>
-      {element}
-    </StyledSectionDividerContent>
-  ));
+  const wrappedChildren = Children.toArray(
+    children.map((element) => (
+      <StyledSectionDividerContent alignItems={alignItems}>
+        {element}
+      </StyledSectionDividerContent>
+    ))
+  );
 
   return (
     <TitleSectionContainer

--- a/src/components/domain/SectionDividerWithTitle/types.ts
+++ b/src/components/domain/SectionDividerWithTitle/types.ts
@@ -8,7 +8,7 @@ interface SectionDividerWithTitleProps
       'titleColor' | 'titleText' | 'titleSize' | 'gap' | 'bold' | 'alignItems'
     >,
     Pick<SectionDividerProps, 'ratio' | 'dividerOptions' | 'width' | 'height'> {
-  children: ReactChild | ReactChild[];
+  children: ReactChild[];
   showContentsDivider?: boolean;
   withHeader?: boolean;
 }

--- a/src/components/domain/UserForm/index.tsx
+++ b/src/components/domain/UserForm/index.tsx
@@ -1,12 +1,13 @@
 import TextButton from '@compound/TextButton';
 import useForm from '@hooks/useForm';
 import type { ReactElement } from 'react';
-import { useEffect, useMemo } from 'react';
+import { useEffect, useMemo, useCallback, useState } from 'react';
 import { StyledForm } from './styled';
 import type { UserFormProps } from './types';
 import UserInput from '../../compound/UserInput';
 import { validateUser } from '@utils/lib/userValidator';
 import { Text } from '@base';
+import type { IUserForm } from '@models';
 
 const UserForm = ({
   type = 'Register',
@@ -20,12 +21,14 @@ const UserForm = ({
   onSubmit,
   ...props
 }: UserFormProps): ReactElement => {
-  const { values, errors, isLoading, handleChange, handleSubmit } = useForm({
-    initialValues,
-    validateOnChange: true,
-    onSubmit,
-    validateFn: validateUser
-  });
+  const { values, errors, isLoading, handleChange, handleSubmit } =
+    useForm<IUserForm>({
+      initialValues,
+      validateOnChange: true,
+      onSubmit,
+      validateFn: validateUser
+    });
+  const [nicknameChecked, setNicknameChecked] = useState(false);
   const validatedValues = useMemo(
     () =>
       Object.values(values).filter((value) => value).length -
@@ -33,9 +36,15 @@ const UserForm = ({
     [values, errors]
   );
   const isValuesAllValidated = useMemo(
-    () => Object.keys(initialValues).length - validatedValues === 0,
-    [initialValues, validatedValues]
+    () =>
+      Object.keys(initialValues).length - validatedValues === 0 &&
+      nicknameChecked,
+    [initialValues, validatedValues, nicknameChecked]
   );
+
+  const handleNickNameChecked = useCallback((value: boolean) => {
+    setNicknameChecked(value);
+  }, []);
 
   useEffect(() => {
     onValidatedValuesChanged?.(validatedValues);
@@ -50,14 +59,15 @@ const UserForm = ({
         errorMessage={errors.nickname}
         formType={type}
         inputType='nickname'
-        value={values.nickname}
+        value={values.nickname || ''}
         onChange={handleChange}
+        onNicknameChecked={handleNickNameChecked}
       />
       <UserInput
         errorMessage={errors.gender}
         formType={type}
         inputType='gender'
-        value={values.gender}
+        value={values.gender || ''}
         onChange={handleChange}
       />
 
@@ -65,7 +75,7 @@ const UserForm = ({
         errorMessage={errors.age}
         formType={type}
         inputType='age'
-        value={values.age}
+        value={values.age || ''}
         onChange={handleChange}
       />
 
@@ -73,7 +83,7 @@ const UserForm = ({
         errorMessage={errors.mbti}
         formType={type}
         inputType='mbti'
-        value={values.mbti}
+        value={values.mbti || ''}
         onChange={handleChange}
       />
       <TextButton

--- a/src/components/domain/UserForm/types.ts
+++ b/src/components/domain/UserForm/types.ts
@@ -1,9 +1,9 @@
-import type { IUserFormType } from '@models';
+import type { IUserForm, IUserFormType } from '@models';
 import type { HTMLAttributes } from 'react';
 
 interface UserFormProps extends HTMLAttributes<HTMLFormElement> {
   type: IUserFormType;
-  initialValues: { [key: string]: any };
+  initialValues?: Partial<IUserForm>;
   onSubmit?(values: { [key: string]: any }): void;
   onValidatedValuesChanged?(value: number): void;
 }

--- a/src/hooks/useForm.ts
+++ b/src/hooks/useForm.ts
@@ -2,15 +2,15 @@ import type { ChangeEventHandler, FormEventHandler } from 'react';
 import { useCallback, useState } from 'react';
 
 interface UseFormProps<T extends { [key: string]: any }> {
-  initialValues: T;
+  initialValues: Partial<T>;
   validateOnChange?: boolean;
-  onSubmit?(value: T): any;
+  onSubmit?(value: Partial<T>): any;
   validateFn?(args: any): any;
 }
 
 interface UseFormReturnType<T extends { [key: string]: any }> {
-  values: T;
-  errors: Partial<T>;
+  values: Partial<T>;
+  errors: { [key: string]: any };
   isLoading: boolean;
   handleChange: ChangeEventHandler<HTMLSelectElement | HTMLInputElement>;
   handleSubmit: FormEventHandler;
@@ -22,7 +22,7 @@ const useForm = <T>({
   onSubmit, // Submit 이벤트
   validateFn // validate 함수
 }: UseFormProps<T>): UseFormReturnType<T> => {
-  const [values, setValues] = useState<T>(initialValues); // Form 내부 값
+  const [values, setValues] = useState<Partial<T>>(initialValues); // Form 내부 값
   const [errors, setErrors] = useState<Partial<T>>({}); // validate Errors
   const [isLoading, setIsLoading] = useState(false); // submit 진행중 여부
 

--- a/src/hooks/useForm.ts
+++ b/src/hooks/useForm.ts
@@ -1,29 +1,29 @@
 import type { ChangeEventHandler, FormEventHandler } from 'react';
 import { useCallback, useState } from 'react';
 
-interface UseFormProps {
-  initialValues: { [key: string]: any };
+interface UseFormProps<T extends { [key: string]: any }> {
+  initialValues: T;
   validateOnChange?: boolean;
-  onSubmit?(value: { [key: string]: any }): any;
+  onSubmit?(value: T): any;
   validateFn?(args: any): any;
 }
 
-interface UseFormReturnType {
-  values: { [key: string]: any };
-  errors: { [key: string]: any };
+interface UseFormReturnType<T extends { [key: string]: any }> {
+  values: T;
+  errors: Partial<T>;
   isLoading: boolean;
   handleChange: ChangeEventHandler<HTMLSelectElement | HTMLInputElement>;
   handleSubmit: FormEventHandler;
 }
 
-const useForm = ({
+const useForm = <T>({
   initialValues, // 초기값
   validateOnChange = false, // onChange event시 validate 진행 여부
   onSubmit, // Submit 이벤트
   validateFn // validate 함수
-}: UseFormProps): UseFormReturnType => {
-  const [values, setValues] = useState(initialValues || {}); // Form 내부 값
-  const [errors, setErrors] = useState<{ [key: string]: any }>({}); // validate Errors
+}: UseFormProps<T>): UseFormReturnType<T> => {
+  const [values, setValues] = useState<T>(initialValues); // Form 내부 값
+  const [errors, setErrors] = useState<Partial<T>>({}); // validate Errors
   const [isLoading, setIsLoading] = useState(false); // submit 진행중 여부
 
   const handleChange: ChangeEventHandler<HTMLSelectElement | HTMLInputElement> =
@@ -36,7 +36,7 @@ const useForm = ({
           setErrors((prevErrors) => {
             // 해당 name value에 error 가 없으면
             if (!Object.keys(newError).length) {
-              delete prevErrors[name]; // 기존 error 객체에서 name property 삭제
+              delete prevErrors[name as keyof T]; // 기존 error 객체에서 name property 삭제
             }
             return { ...prevErrors, ...newError }; // 새로운 error 객체 반환
           });

--- a/src/models/types.ts
+++ b/src/models/types.ts
@@ -87,12 +87,20 @@ interface IIngredient {
 
 interface IUser {
   id: string;
-  nickName: string;
+  email: string;
+  nickname: string;
   isMan: boolean;
   age: number;
   mbti: IUserMbti;
   myIngredients?: IIngredient[];
   favorites?: Pick<ICocktail, 'id'>[];
+}
+
+interface IUserForm {
+  nickname: string | null;
+  gender: IUserGender | null;
+  age: number | null;
+  mbti: IUserMbti | null;
 }
 
 type IDomain = typeof DOMAINS[keyof typeof DOMAINS];
@@ -108,6 +116,7 @@ export type {
   ITHEME,
   IUserInputType,
   IUserFormType,
+  IUserForm,
   IUserGender,
   IUserMbti,
   ValidateFnType,

--- a/src/pages/MyPage/index.tsx
+++ b/src/pages/MyPage/index.tsx
@@ -7,6 +7,7 @@ import { useSearchParams } from 'react-router-dom';
 import UserForm from '@domain/UserForm';
 import CocktailList from '@domain/CocktailList';
 import SectionDividerWithTitle from '@domain/SectionDividerWithTitle';
+import type { IUserForm } from '@models';
 
 const TEN_RADIX = 10;
 
@@ -17,7 +18,12 @@ const MyPage = (): ReactElement => {
     [searchParams]
   );
   // 유저 임시정보
-  const user = { nickname: 'Alang', age: 15, gender: '남자', mbti: 'INFP' };
+  const user: IUserForm = {
+    nickname: 'Alang',
+    age: 15,
+    gender: '남자',
+    mbti: 'INFP'
+  };
   // 칵테일 임시정보
   const cocktails: any[] = [];
   const handleChangeItem = (index: number): void => {

--- a/src/pages/RegisterPage/index.tsx
+++ b/src/pages/RegisterPage/index.tsx
@@ -5,6 +5,7 @@ import RegisterModal from '@domain/RegisterModal';
 import type { IUser, IUserForm } from '@models';
 import type { ReactElement } from 'react';
 import { useNavigate } from 'react-router';
+import type { IRegisterRequestBody } from './types';
 
 // test email
 const TEST_EMAIL = 'rlaangh77@naver.com';
@@ -13,7 +14,7 @@ const RegisterPage = (): ReactElement => {
   const navigate = useNavigate();
 
   const postRegister = async (
-    values: Partial<IUser>
+    values: IRegisterRequestBody
   ): Promise<IUser | undefined> => {
     console.log(values);
     const data = await request.post<IUser, IUser>('/user/join', values);
@@ -27,17 +28,16 @@ const RegisterPage = (): ReactElement => {
     console.log(TEST_EMAIL);
     console.log('posting!');
     const { nickname, age, gender, mbti } = value;
-    request.get('user/nickname/alangGY').then((data) => {
+    if (nickname && age && gender && mbti) {
+      const data = await postRegister({
+        nickname,
+        age,
+        mbti,
+        isMan: gender === '남자' ? true : false,
+        email: TEST_EMAIL
+      });
       console.log(data);
-    });
-    const data = await postRegister({
-      nickname,
-      age,
-      mbti,
-      isMan: gender === '남자' ? true : false,
-      email: TEST_EMAIL
-    });
-    console.log(data);
+    }
   };
 
   return (

--- a/src/pages/RegisterPage/index.tsx
+++ b/src/pages/RegisterPage/index.tsx
@@ -1,14 +1,48 @@
+import { request } from '@apis/config';
 import { StyledPageContainerWithBackground } from '@base/PageContainerWithBackground/styled';
 import BackButton from '@domain/BackButton';
 import RegisterModal from '@domain/RegisterModal';
+import type { IUser, IUserForm } from '@models';
 import type { ReactElement } from 'react';
 import { useNavigate } from 'react-router';
 
+// test email
+const TEST_EMAIL = 'rlaangh77@naver.com';
+
 const RegisterPage = (): ReactElement => {
   const navigate = useNavigate();
+
+  const postRegister = async (
+    values: Partial<IUser>
+  ): Promise<IUser | undefined> => {
+    console.log(values);
+    const data = await request.post<IUser, IUser>('/user/join', values);
+    if (data) {
+      return data;
+    }
+  };
+
+  const handleRegister = async (value: IUserForm): Promise<any> => {
+    console.log(value);
+    console.log(TEST_EMAIL);
+    console.log('posting!');
+    const { nickname, age, gender, mbti } = value;
+    request.get('user/nickname/alangGY').then((data) => {
+      console.log(data);
+    });
+    const data = await postRegister({
+      nickname,
+      age,
+      mbti,
+      isMan: gender === '남자' ? true : false,
+      email: TEST_EMAIL
+    });
+    console.log(data);
+  };
+
   return (
     <StyledPageContainerWithBackground>
-      <RegisterModal />
+      <RegisterModal onSubmit={handleRegister} />
       <BackButton
         color='NAVY'
         onClick={(): void => {

--- a/src/pages/RegisterPage/types.ts
+++ b/src/pages/RegisterPage/types.ts
@@ -1,0 +1,11 @@
+import type { IUserMbti } from '@models';
+
+interface IRegisterRequestBody {
+  email: string;
+  nickname: string;
+  isMan: boolean;
+  age: number;
+  mbti: IUserMbti;
+}
+
+export type { IRegisterRequestBody };

--- a/src/stories/domain/CocktailReviewModal.stories.tsx
+++ b/src/stories/domain/CocktailReviewModal.stories.tsx
@@ -30,7 +30,7 @@ export const Default = (): ReactElement => {
       </button>
       <p>
         <label>{'파일이름'}</label>
-        <div>{userReview ? userReview.userFile.name : '-'}</div>
+        <div>{userReview ? userReview.userFile?.name : '-'}</div>
         <label>{'평점'}</label>
         <div>{userReview ? userReview.userRate.toString() : '0'}</div>
         <label>{'한줄 평'}</label>

--- a/src/stories/domain/SectionDividerWithTitle.stories.tsx
+++ b/src/stories/domain/SectionDividerWithTitle.stories.tsx
@@ -31,10 +31,7 @@ export const Default = (args: SectionDividerWithTitleProps): ReactElement => (
       />
     </div>
     <div>
-      <UserForm
-        initialValues={{ nickname: null, gender: null, age: null, mbti: null }}
-        type='Register'
-      />
+      <UserForm type='Register' />
     </div>
   </SectionDividerWithTitle>
 );


### PR DESCRIPTION
## 📌 내용 설명 <!-- 구현한 내용의 핵심 요약 -->
userinput에서 nickname 중복 검사기능을 추가하였습니다.
userForm에서 nickname 중복검사가 진행된후에만 onSubmit이 가능합니다.
## 👀 이미지 또는 Gif <!-- 구현한 내용의 동작을 담은 이미지, gif 등. 시각화된 내용이 없다면 생략 -->
![화면 기록 2021-12-15 오전 1 06 11](https://user-images.githubusercontent.com/75013334/146037764-d168ec0d-e2a5-4b43-8d14-df70aefcd92f.gif)

## 📝 요구 사항 <!-- 구현한 내용의 세부 사항 목록과 완료 여부 체크 -->

## 💡 포인트 <!-- 구현한 내용 중 추가 설명, 강조가 필요한 핵심 로직이나 코드 설명. '특히 자세히 봐줬으면 좋겠다!'하는 내용들 -->

## 🚩 이슈 <!-- 해결하지 못한 내용 또는 부족한 점이 있어 추가 논의가 필요할 것 같은 부분에 대한 상세 설명 -->
userInput에서  nickname, gender, age, mbti에 대해서 모두 처리하다보니, nickname에만 필요한 상태들이 불필요하게 호출되게됩니다. 이후에 리팩토링할 요소로 보입니다.
## 🛠 피드백 반영 사항 <!-- 회의 또는 리뷰를 통해 발견하여 수정한 내역에 대한 설명-->
