### PR TITLE
refactor: SM-165 Theme Selector 아이콘들 적용

### DIFF
--- a/src/assets/carouselTheme/big/index.ts
+++ b/src/assets/carouselTheme/big/index.ts
@@ -1,0 +1,19 @@
+import COLOR from './color.png';
+import EDIT_PROFILE from './editProfile.png';
+import FAVORITES from './favorites.png';
+import MBTI from './mbti.png';
+import MOOD from './mood.png';
+import MUSIC from './music.png';
+import TRENDING from './trending.png';
+import WEATHER from './weather.png';
+
+export default {
+  COLOR,
+  EDIT_PROFILE,
+  FAVORITES,
+  MBTI,
+  MOOD,
+  MUSIC,
+  TRENDING,
+  WEATHER
+} as const;

--- a/src/assets/carouselTheme/colorIcons/index.ts
+++ b/src/assets/carouselTheme/colorIcons/index.ts
@@ -1,0 +1,19 @@
+import BLACK from './black.png';
+import BLUE from './blue.png';
+import GREEN from './green.png';
+import ORANGE from './orange.png';
+import PURPLE from './purple.png';
+import RED from './red.png';
+import WHITE from './white.png';
+import YELLOW from './yellow.png';
+
+export default {
+  RED,
+  ORANGE,
+  YELLOW,
+  GREEN,
+  BLUE,
+  PURPLE,
+  WHITE,
+  BLACK
+} as const;

--- a/src/assets/carouselTheme/index.ts
+++ b/src/assets/carouselTheme/index.ts
@@ -1,0 +1,13 @@
+import COLORS from './colorIcons';
+import MBTIS from './mbtiIcons';
+import MOODS from './moodIcons';
+import MUSICS from './musicIcons';
+import WEATHERS from './weatherIcons';
+
+export default {
+  COLOR: COLORS,
+  MBTI: MBTIS,
+  MOOD: MOODS,
+  MUSIC: MUSICS,
+  WEATHER: WEATHERS
+} as const;

--- a/src/assets/carouselTheme/mbtiIcons/index.ts
+++ b/src/assets/carouselTheme/mbtiIcons/index.ts
@@ -1,0 +1,35 @@
+import ENFJ from './enfj.png';
+import ENFP from './enfp.png';
+import ENTJ from './entj.png';
+import ENTP from './entp.png';
+import ESFJ from './esfj.png';
+import ESFP from './esfp.png';
+import ESTJ from './estj.png';
+import ESTP from './estp.png';
+import INFJ from './infj.png';
+import INFP from './infp.png';
+import INTJ from './intj.png';
+import INTP from './intp.png';
+import ISFJ from './isfj.png';
+import ISFP from './isfp.png';
+import ISTJ from './istj.png';
+import ISTP from './istp.png';
+
+export default {
+  ENFJ,
+  ENFP,
+  ENTJ,
+  ENTP,
+  ESFJ,
+  ESFP,
+  ESTJ,
+  ESTP,
+  INFJ,
+  INFP,
+  INTJ,
+  INTP,
+  ISFJ,
+  ISFP,
+  ISTJ,
+  ISTP
+} as const;

--- a/src/assets/carouselTheme/moodIcons/index.ts
+++ b/src/assets/carouselTheme/moodIcons/index.ts
@@ -1,0 +1,13 @@
+import ANGRY from './angry.png';
+import HAPPY from './happy.png';
+import LONELY from './lonely.png';
+import ROMANTIC from './romantic.png';
+import SAD from './sad.png';
+
+export default {
+  ANGRY,
+  HAPPY,
+  LONELY,
+  ROMANTIC,
+  SAD
+} as const;

--- a/src/assets/carouselTheme/musicIcons/index.ts
+++ b/src/assets/carouselTheme/musicIcons/index.ts
@@ -1,0 +1,15 @@
+import BALLAD from './ballad.png';
+import CLASSIC from './classic.png';
+import HIPHOP from './hiphop.png';
+import INDIE from './indie.png';
+import JAZZ from './jazz.png';
+import ROCK from './rock.png';
+
+export default {
+  BALLAD,
+  CLASSIC,
+  HIPHOP,
+  INDIE,
+  JAZZ,
+  ROCK
+} as const;

--- a/src/assets/carouselTheme/weatherIcons/index.ts
+++ b/src/assets/carouselTheme/weatherIcons/index.ts
@@ -1,0 +1,11 @@
+import CLOUDY from './cloudy.png';
+import RAINY from './rainy.png';
+import SNOWY from './snowy.png';
+import SUNNY from './sunny.png';
+
+export default {
+  CLOUDY,
+  RAINY,
+  SNOWY,
+  SUNNY
+} as const;

--- a/src/components/base/Image/index.tsx
+++ b/src/components/base/Image/index.tsx
@@ -28,7 +28,7 @@ const Image = ({
   alt,
   mode = 'cover',
   block = false,
-  placeholder = 'https://via.placeholder.com/300',
+  placeholder,
   threshold = DEFAULT_THRESHOLD,
   ...props
 }: ImageProps): ReactElement => {

--- a/src/components/compound/Carousel/CarouselItem/index.tsx
+++ b/src/components/compound/Carousel/CarouselItem/index.tsx
@@ -44,7 +44,7 @@ const CarouselItem = ({
               ? CAROUSEL_IMAGE_SIZE.withTitle.height
               : CAROUSEL_IMAGE_SIZE.withoutTitle.height
           }
-          mode='fill'
+          mode='contain'
           src={imageSrc}
           width={
             title

--- a/src/components/domain/ThemeSelector/index.tsx
+++ b/src/components/domain/ThemeSelector/index.tsx
@@ -6,7 +6,8 @@ import type { ReactElement } from 'react';
 import { useMemo, useState, useEffect } from 'react';
 import { SectionDividerContent } from './styled';
 import type { ThemeSelectorProps } from './types';
-import imageSrc from '@assets/carouselTheme/big/color.png';
+import mainImageSrcs from '@assets/carouselTheme/big';
+import detailImageSrcs from '@assets/carouselTheme';
 
 const ThemeSelector = ({
   initialMainIndex = 0,
@@ -21,6 +22,11 @@ const ThemeSelector = ({
     () => (Object.keys(THEMES) as ITHEME[])[selectedMainIndex],
     [selectedMainIndex]
   );
+  const selectedDetailNames = useMemo(
+    () => THEMES[selectedThemeName],
+    [selectedThemeName]
+  );
+
   const handleChangeMain = (value: number): void => {
     setSelectedMainIndex(value);
     setSelectedDetailIndex(0);
@@ -48,8 +54,13 @@ const ThemeSelector = ({
           selectedIndex={selectedMainIndex}
           onChangeItem={handleChangeMain}
         >
-          {Object.keys(THEMES).map((theme) => (
-            <Carousel.Item key={theme} imageSrc={imageSrc} title={theme} />
+          {(Object.keys(THEMES) as ITHEME[]).map((theme) => (
+            <Carousel.Item
+              key={theme}
+              backgroundColor='ORANGE'
+              imageSrc={mainImageSrcs[theme]}
+              title={theme}
+            />
           ))}
         </Carousel.Container>
       </SectionDividerContent>
@@ -58,12 +69,19 @@ const ThemeSelector = ({
           selectedIndex={selectedDetailIndex}
           onChangeItem={handleChangeDetail}
         >
-          {THEMES[selectedThemeName].map((detailTheme) => (
+          {selectedDetailNames.map((detailTheme) => (
             <Carousel.Item
               key={detailTheme}
-              backgroundColor='LIGHT_PINK'
-              imageSrc='https://picsum.photos/200'
-              title={detailTheme}
+              backgroundColor='BROWN'
+              // 여기서 조금 더 정확한 타입명시를 하는 방법은 없을까
+              imageSrc={
+                (
+                  detailImageSrcs[selectedThemeName] as {
+                    [key: string]: string;
+                  }
+                )[detailTheme]
+              }
+              title={selectedThemeName !== 'MBTI' ? detailTheme : undefined}
             />
           ))}
         </Carousel.Container>

--- a/src/utils/constants/themes.ts
+++ b/src/utils/constants/themes.ts
@@ -13,7 +13,7 @@ const THEME_COLOR = [
 const THEME_MUSIC = [
   'JAZZ',
   'ROCK',
-  'BALAD',
+  'BALLAD',
   'HIPHOP',
   'CLASSIC',
   'INDIE'
@@ -36,15 +36,15 @@ const THEME_MBTI = [
   'ESTP',
   'ESFP'
 ] as const;
-const THEME_TRENDING = ['MAN', 'FEMALE'] as const;
+// const THEME_TRENDING = ['MAN', 'FEMALE'] as const;
 
 const THEMES = {
   MOOD: THEME_MOOD,
   WEATHER: THEME_WEATHER,
   COLOR: THEME_COLOR,
   MUSIC: THEME_MUSIC,
-  MBTI: THEME_MBTI,
-  TRENDING: THEME_TRENDING
+  MBTI: THEME_MBTI
+  // TRENDING: THEME_TRENDING
 } as const;
 
 export { THEMES };


### PR DESCRIPTION
## 📌 내용 설명 <!-- 구현한 내용의 핵심 요약 -->
Theme Selector에 해당되는 아이콘들을 적용하였습니다.
## 👀 이미지 또는 Gif <!-- 구현한 내용의 동작을 담은 이미지, gif 등. 시각화된 내용이 없다면 생략 -->
![화면 기록 2021-12-16 오후 1 38 51](https://user-images.githubusercontent.com/75013334/146309327-4eba776e-2d45-4ada-93fb-546ca3d5151b.gif)

## 📝 요구 사항 <!-- 구현한 내용의 세부 사항 목록과 완료 여부 체크 -->
이미지또한 마찬가지로 THEME상수의 키값과 동일한형태로 매핑하였습니다.
## 💡 포인트 <!-- 구현한 내용 중 추가 설명, 강조가 필요한 핵심 로직이나 코드 설명. '특히 자세히 봐줬으면 좋겠다!'하는 내용들 -->
1. assets의 각폴더에서 index.ts를 작성하여 하나의 객체로 import하여 사용할수있게끔하였습니다.
## 🚩 이슈 <!-- 해결하지 못한 내용 또는 부족한 점이 있어 추가 논의가 필요할 것 같은 부분에 대한 상세 설명 -->
![image](https://user-images.githubusercontent.com/75013334/146309568-aaec45fc-6d0a-448d-8b7c-74e61ef752fd.png)
해당부분에서 어쩔수없이 [key: string]: string와 같은 any나 다를바없는 타입assertion이 이루어져있습니다. 좀 더 정확하게 타입명시를 할수있는 방법에 대해서 고민이 됩니다.
## 🛠 피드백 반영 사항 <!-- 회의 또는 리뷰를 통해 발견하여 수정한 내역에 대한 설명-->
