### PR TITLE
Feat/sm 186/ingredient item

### DIFF
--- a/src/components/domain/CocktailDetailModal/IngredientItem/index.tsx
+++ b/src/components/domain/CocktailDetailModal/IngredientItem/index.tsx
@@ -1,9 +1,11 @@
 import type { ReactElement } from 'react';
-import { Text } from '@base';
-// import Image from '@base/Image';
+import { useNavigate } from 'react-router-dom';
+import { IngredientIcons } from '@assets/ingredients';
+import { Text, Image } from '@base';
+import type { IngredientIconsKeys } from '@domain/IngredientCarousel/types';
+import { INGREDIENT_ICON_SIZE } from './types';
 import type { IngredientItemProps } from './types';
 import { StyledIngredient } from './style';
-import { useNavigate } from 'react-router-dom';
 
 const IngredientItem = (ingredient: IngredientItemProps): ReactElement => {
   const navigate = useNavigate();
@@ -21,7 +23,12 @@ const IngredientItem = (ingredient: IngredientItemProps): ReactElement => {
             }
       }
     >
-      {/* <Image src=`` /> */}
+      <Image
+        height={INGREDIENT_ICON_SIZE.height}
+        mode='cover'
+        src={IngredientIcons[ingredient.type as IngredientIconsKeys]}
+        width={INGREDIENT_ICON_SIZE.width}
+      />
       <Text size='xs'>{ingredient.name}</Text>
       <Text size='xs'>{ingredient.amount.toString()}</Text>
       <Text size='xs'>{ingredient.measure}</Text>

--- a/src/components/domain/CocktailDetailModal/IngredientItem/index.tsx
+++ b/src/components/domain/CocktailDetailModal/IngredientItem/index.tsx
@@ -5,10 +5,16 @@ import { Text, Image } from '@base';
 import type { IngredientIconsKeys } from '@domain/IngredientCarousel/types';
 import { INGREDIENT_ICON_SIZE } from './types';
 import type { IngredientItemProps } from './types';
-import { StyledIngredient } from './style';
+import {
+  StyledIngredient,
+  StyledIngredientInnerWrapper,
+  StyledAmoutMeasureWrapper,
+  StyledHasWrapper
+} from './style';
 
 const IngredientItem = (ingredient: IngredientItemProps): ReactElement => {
   const navigate = useNavigate();
+  const innerTextColor = ingredient.isUserHas ? 'BLACK' : 'BASIC_WHITE';
   return (
     <StyledIngredient
       isUserHas={ingredient.isUserHas}
@@ -23,29 +29,46 @@ const IngredientItem = (ingredient: IngredientItemProps): ReactElement => {
             }
       }
     >
-      <Image
-        height={INGREDIENT_ICON_SIZE.height}
-        mode='cover'
-        src={IngredientIcons[ingredient.type as IngredientIconsKeys]}
-        width={INGREDIENT_ICON_SIZE.width}
-      />
-      <Text size='xs'>{ingredient.name}</Text>
-      <Text size='xs'>{ingredient.amount.toString()}</Text>
-      <Text size='xs'>{ingredient.measure}</Text>
-      {ingredient.isUserHas ? (
-        <Text block={false} size='xxs' style={{ float: 'right' }}>
-          {'보유중'}
+      <StyledIngredientInnerWrapper>
+        <Image
+          height={INGREDIENT_ICON_SIZE.height}
+          mode='cover'
+          src={IngredientIcons[ingredient.type as IngredientIconsKeys]}
+          width={INGREDIENT_ICON_SIZE.width}
+        />
+        <Text color={innerTextColor} size='xs'>
+          {ingredient.name}
         </Text>
-      ) : (
-        <Text
-          block={false}
-          color='BASIC_WHITE'
-          size='xxs'
-          style={{ float: 'right' }}
-        >
-          {'구매하기'}
-        </Text>
-      )}
+        <StyledAmoutMeasureWrapper>
+          <Text color={innerTextColor} size='xs'>
+            {ingredient.amount.toString()}
+          </Text>
+          <Text color={innerTextColor} size='xs'>
+            {ingredient.measure}
+          </Text>
+        </StyledAmoutMeasureWrapper>
+        <StyledHasWrapper>
+          {ingredient.isUserHas ? (
+            <Text
+              block={false}
+              color={innerTextColor}
+              size='xxs'
+              style={{ float: 'right' }}
+            >
+              {'보유중'}
+            </Text>
+          ) : (
+            <Text
+              block={false}
+              color={innerTextColor}
+              size='xxs'
+              style={{ float: 'right' }}
+            >
+              {'구매하기'}
+            </Text>
+          )}
+        </StyledHasWrapper>
+      </StyledIngredientInnerWrapper>
     </StyledIngredient>
   );
 };

--- a/src/components/domain/CocktailDetailModal/IngredientItem/index.tsx
+++ b/src/components/domain/CocktailDetailModal/IngredientItem/index.tsx
@@ -8,7 +8,7 @@ import type { IngredientItemProps } from './types';
 import {
   StyledIngredient,
   StyledIngredientInnerWrapper,
-  StyledAmoutMeasureWrapper,
+  StyledNameAmoutMeasureWrapper,
   StyledHasWrapper
 } from './style';
 
@@ -36,17 +36,15 @@ const IngredientItem = (ingredient: IngredientItemProps): ReactElement => {
           src={IngredientIcons[ingredient.type as IngredientIconsKeys]}
           width={INGREDIENT_ICON_SIZE.width}
         />
-        <Text color={innerTextColor} size='xs'>
-          {ingredient.name}
-        </Text>
-        <StyledAmoutMeasureWrapper>
+        <StyledNameAmoutMeasureWrapper>
           <Text color={innerTextColor} size='xs'>
-            {ingredient.amount.toString()}
+            {ingredient.name +
+              ' ' +
+              ingredient.amount.toString() +
+              ' ' +
+              ingredient.measure}
           </Text>
-          <Text color={innerTextColor} size='xs'>
-            {ingredient.measure}
-          </Text>
-        </StyledAmoutMeasureWrapper>
+        </StyledNameAmoutMeasureWrapper>
         <StyledHasWrapper>
           {ingredient.isUserHas ? (
             <Text

--- a/src/components/domain/CocktailDetailModal/IngredientItem/style.ts
+++ b/src/components/domain/CocktailDetailModal/IngredientItem/style.ts
@@ -4,6 +4,7 @@ import type { IngredientItemProps } from './types';
 
 const StyledIngredient = styled.div<Pick<IngredientItemProps, 'isUserHas'>>`
   display: flex;
+  justify-content: center;
   align-items: center;
   width: 339px;
   height: 48px;

--- a/src/components/domain/CocktailDetailModal/IngredientItem/style.ts
+++ b/src/components/domain/CocktailDetailModal/IngredientItem/style.ts
@@ -21,12 +21,12 @@ const StyledIngredientInnerWrapper = styled.div`
   width: 317.49px;
   height: 32px;
 `;
-const StyledAmoutMeasureWrapper = styled.div``;
+const StyledNameAmoutMeasureWrapper = styled.div``;
 const StyledHasWrapper = styled.div``;
 
 export {
   StyledIngredient,
   StyledIngredientInnerWrapper,
-  StyledAmoutMeasureWrapper,
+  StyledNameAmoutMeasureWrapper,
   StyledHasWrapper
 };

--- a/src/components/domain/CocktailDetailModal/IngredientItem/style.ts
+++ b/src/components/domain/CocktailDetailModal/IngredientItem/style.ts
@@ -3,6 +3,8 @@ import styled from '@emotion/styled';
 import type { IngredientItemProps } from './types';
 
 const StyledIngredient = styled.div<Pick<IngredientItemProps, 'isUserHas'>>`
+  display: flex;
+  align-items: center;
   width: 339px;
   height: 48px;
   background: ${({ isUserHas }): string =>
@@ -12,5 +14,19 @@ const StyledIngredient = styled.div<Pick<IngredientItemProps, 'isUserHas'>>`
   margin: 9px;
   padding: 5px;
 `;
+const StyledIngredientInnerWrapper = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 317.49px;
+  height: 32px;
+`;
+const StyledAmoutMeasureWrapper = styled.div``;
+const StyledHasWrapper = styled.div``;
 
-export { StyledIngredient };
+export {
+  StyledIngredient,
+  StyledIngredientInnerWrapper,
+  StyledAmoutMeasureWrapper,
+  StyledHasWrapper
+};

--- a/src/components/domain/CocktailDetailModal/IngredientItem/types.ts
+++ b/src/components/domain/CocktailDetailModal/IngredientItem/types.ts
@@ -9,4 +9,11 @@ interface IngredientObject {
 interface IngredientItemProps extends IngredientObject {
   isUserHas: boolean;
 }
+
+const INGREDIENT_ICON_SIZE = {
+  width: '32px',
+  height: '32px'
+};
+
+export { INGREDIENT_ICON_SIZE };
 export type { IngredientObject, IngredientItemProps };


### PR DESCRIPTION
## 📌 내용 설명 <!-- 구현한 내용의 핵심 요약 -->
칵테일 상세 모달의 '재료 아이템'의 스타일을 개선했습니다.
## 👀 이미지 또는 Gif <!-- 구현한 내용의 동작을 담은 이미지, gif 등. 시각화된 내용이 없다면 생략 -->
![image](https://user-images.githubusercontent.com/44149596/146589003-33947ec8-4518-4743-80ee-d329b3c0b780.png)

## 📝 요구 사항 <!-- 구현한 내용의 세부 사항 목록과 완료 여부 체크 -->
- 재료의 `type`에 맞는 아이콘을 재료 아이템 좌측에 렌더링합니다.
- 보유하고 있는 재료와 보유하고 있지 않은 재료 아이템 간 텍스트 색상을 다르게 주었습니다.
- `flex` `justify-content: space-between` 를 사용하여 아이콘, 재료, 보유여부 간격을 균등하게 주었습니다.
## 💡 포인트 <!-- 구현한 내용 중 추가 설명, 강조가 필요한 핵심 로직이나 코드 설명. '특히 자세히 봐줬으면 좋겠다!'하는 내용들 -->

## 🚩 이슈 <!-- 해결하지 못한 내용 또는 부족한 점이 있어 추가 논의가 필요할 것 같은 부분에 대한 상세 설명 -->

## 🛠 피드백 반영 사항 <!-- 회의 또는 리뷰를 통해 발견하여 수정한 내역에 대한 설명-->
