### PR TITLE
fix: SM-187 CocktailDetailModal CocktailList 하위로 이동 및 Style 수정

### DIFF
--- a/src/components/domain/CocktailDetailModal/index.tsx
+++ b/src/components/domain/CocktailDetailModal/index.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import type { ReactElement } from 'react';
 import type { Review } from '@domain/CocktailReviewModal/types';
 import type { CocktailDetailModalProps } from './types';
-import { Image, SectionDivider, Modal, Text } from '@base';
+import { Image, SectionDivider, Text } from '@base';
 import IngredientItem from './IngredientItem';
 import UserReviewItem from './UserReviewItem';
 import { TextButton, MenuTab, IconToggle } from '@compound';
@@ -10,7 +10,8 @@ import { TitleSectionContainer, CocktailReviewModal } from '@domain';
 import {
   StyledIngredientListWrapper,
   StyledReviewListWrapper,
-  StyledImageContainer
+  StyledImageContainer,
+  StyledModal
 } from './style';
 import { MOCK_USER_INGREDIENT_IDS } from './types';
 import useAxios from '@hooks/useAxios';
@@ -82,7 +83,7 @@ const CocktailDetailModal = ({
   };
 
   return (
-    <Modal
+    <StyledModal
       backgroundColor={backgroundColor}
       color={color}
       size={size}
@@ -191,7 +192,7 @@ const CocktailDetailModal = ({
           )}
         </>
       )}
-    </Modal>
+    </StyledModal>
   );
 };
 

--- a/src/components/domain/CocktailDetailModal/style.ts
+++ b/src/components/domain/CocktailDetailModal/style.ts
@@ -1,3 +1,4 @@
+import { Modal } from '@base';
 import { COLOR } from '@constants';
 import styled from '@emotion/styled';
 
@@ -9,6 +10,11 @@ const StyledLeftSection = styled.div`
 const StyledRightSection = styled.div`
   background-color: ${COLOR.IVORY};
   overflow: hidden;
+`;
+
+const StyledModal = styled(Modal)`
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
 `;
 
 const StyledIngredientListWrapper = styled.div`
@@ -56,6 +62,7 @@ const StyledImageContainer = styled.div`
 `;
 
 export {
+  StyledModal,
   StyledLeftSection,
   StyledRightSection,
   StyledIngredientListWrapper,

--- a/src/components/domain/CocktailList/index.tsx
+++ b/src/components/domain/CocktailList/index.tsx
@@ -1,44 +1,69 @@
-import { Children } from 'react';
+import { Children, useState } from 'react';
 import type { ReactElement } from 'react';
 import { Text } from '@base';
 import { StyledContainer, StyledMotionWrapper } from './styled';
 import type { CocktailListProps, CocktailIconsKeys } from './types';
 import { CocktailIcons, TOTAL_COCKTAIL_ICONS } from '@assets/cocktails';
 import { Album } from '@compound';
+import { CocktailDetailModal } from '@domain';
 
 const DEFAULT_MSG = '죄송합니다. 추천 칵테일이 존재하지 않습니다.';
 
 const CocktailList = ({
   cocktailList = [],
-  noResultMsg = DEFAULT_MSG,
-  handleAlbumClick
+  noResultMsg = DEFAULT_MSG
 }: CocktailListProps): ReactElement => {
+  const [clickedCocktailId, setClickedCocktailId] = useState<number | null>(
+    null
+  );
+  const [isCocktailDetailModalVisible, setIsCocktailDetailModalVisible] =
+    useState<boolean>(false);
+
+  const handleAlbumClick = (cocktailId: number): void => {
+    setClickedCocktailId(cocktailId);
+    setIsCocktailDetailModalVisible(true);
+  };
+
   return (
-    <StyledContainer>
-      {cocktailList.length ? (
-        Children.toArray(
-          cocktailList.map((cocktail, index) => (
-            <StyledMotionWrapper resultIndex={index}>
-              <Album
-                cocktailId={cocktail.id}
-                handleAlbumClick={handleAlbumClick}
-                imageSrc={
-                  CocktailIcons[
-                    (index % TOTAL_COCKTAIL_ICONS) as CocktailIconsKeys
-                  ]
-                }
-                text={cocktail.name}
-                type='result'
-              />
-            </StyledMotionWrapper>
-          ))
-        )
-      ) : (
-        <Text block color='DARK_GRAY' size='md'>
-          {noResultMsg}
-        </Text>
+    <>
+      <StyledContainer>
+        {cocktailList.length ? (
+          Children.toArray(
+            cocktailList.map((cocktail, index) => (
+              <StyledMotionWrapper resultIndex={index}>
+                <Album
+                  cocktailId={cocktail.id}
+                  handleAlbumClick={handleAlbumClick}
+                  imageSrc={
+                    CocktailIcons[
+                      (index % TOTAL_COCKTAIL_ICONS) as CocktailIconsKeys
+                    ]
+                  }
+                  text={cocktail.name}
+                  type='result'
+                />
+              </StyledMotionWrapper>
+            ))
+          )
+        ) : (
+          <Text block color='DARK_GRAY' size='md'>
+            {noResultMsg}
+          </Text>
+        )}
+      </StyledContainer>
+      {clickedCocktailId && (
+        <CocktailDetailModal
+          backgroundColor='DARK_GRAY_OPACITY'
+          clickedCocktailId={clickedCocktailId}
+          color='IVORY'
+          size='lg'
+          visible={isCocktailDetailModalVisible}
+          onClose={(): void => {
+            setIsCocktailDetailModalVisible(false);
+          }}
+        />
       )}
-    </StyledContainer>
+    </>
   );
 };
 

--- a/src/components/domain/CocktailList/types.ts
+++ b/src/components/domain/CocktailList/types.ts
@@ -5,7 +5,6 @@ import type { ICocktailSimple } from '@models/types';
 interface CocktailListProps extends HTMLAttributes<HTMLDivElement> {
   cocktailList: ICocktailSimple[];
   noResultMsg?: string;
-  handleAlbumClick?(id: number): void;
 }
 
 interface StyledMotionWrapperProps {

--- a/src/pages/SearchPage/index.tsx
+++ b/src/pages/SearchPage/index.tsx
@@ -11,17 +11,11 @@ import SectionDividerWithTitle from '@domain/SectionDividerWithTitle';
 import useAxios from '@hooks/useAxios';
 import type { ICocktailSimple, IApiResponse } from '@models/types';
 import { AXIOS_REQUEST_TYPE } from '@constants/axios';
-import { CocktailDetailModal } from '@domain';
 
 const SearchPage = (): ReactElement => {
   const [results, setResults] = useState<ICocktailSimple[]>([]);
   const { keyword } = useParams();
   const navigate = useNavigate();
-  const [clickedCocktailId, setClickedCocktailId] = useState<number | null>(
-    null
-  );
-  const [isCocktailDetailModalVisible, setIsCocktailDetailModalVisible] =
-    useState<boolean>(false);
 
   const request = useAxios(AXIOS_REQUEST_TYPE.DEFAULT);
 
@@ -35,11 +29,6 @@ const SearchPage = (): ReactElement => {
     navigate(`/search/${inputKeyword}`);
   }, []);
 
-  const handleAlbumClick = (cocktailId: number): void => {
-    setClickedCocktailId(cocktailId);
-    setIsCocktailDetailModalVisible(true);
-  };
-
   useEffect(() => {
     const setSearchResults = async (): Promise<void> => {
       if (keyword) {
@@ -51,31 +40,14 @@ const SearchPage = (): ReactElement => {
   }, [keyword]);
 
   return (
-    <>
-      <SectionDividerWithTitle alignItems>
-        <StyledContentWrapper>
-          <Text block>찾아 보고 싶은 칵테일이 있나요?</Text>
-          <Image mode='contain' src={searchBartender} />
-          <SearchCocktailInput onSearch={handleSearch} />
-        </StyledContentWrapper>
-        <CocktailList
-          cocktailList={results}
-          handleAlbumClick={handleAlbumClick}
-        />
-      </SectionDividerWithTitle>
-      {clickedCocktailId && (
-        <CocktailDetailModal
-          backgroundColor='DARK_GRAY'
-          clickedCocktailId={clickedCocktailId}
-          color='IVORY'
-          size='lg'
-          visible={isCocktailDetailModalVisible}
-          onClose={(): void => {
-            setIsCocktailDetailModalVisible(false);
-          }}
-        />
-      )}
-    </>
+    <SectionDividerWithTitle alignItems withHeader>
+      <StyledContentWrapper>
+        <Text block>찾아 보고 싶은 칵테일이 있나요?</Text>
+        <Image mode='contain' src={searchBartender} />
+        <SearchCocktailInput onSearch={handleSearch} />
+      </StyledContentWrapper>
+      <CocktailList cocktailList={results} />
+    </SectionDividerWithTitle>
   );
 };
 


### PR DESCRIPTION
## 📌 내용 설명 <!-- 구현한 내용의 핵심 요약 -->
기존에 Page단에 있는 CocktailDetailModal을 CocktailList 하위로 이동하여 Page별로 컴포넌트를 붙이지 않도록 하였습니다.
Modal 창의 background에 opacity를 부여하였고 작은 style 수정 진행하였습니다.
## 👀 이미지 또는 Gif <!-- 구현한 내용의 동작을 담은 이미지, gif 등. 시각화된 내용이 없다면 생략 -->
![image](https://user-images.githubusercontent.com/75013334/146593700-5e8ce9d5-14ee-4e1b-b5b7-57a6df457a23.png)

## 📝 요구 사항 <!-- 구현한 내용의 세부 사항 목록과 완료 여부 체크 -->

## 💡 포인트 <!-- 구현한 내용 중 추가 설명, 강조가 필요한 핵심 로직이나 코드 설명. '특히 자세히 봐줬으면 좋겠다!'하는 내용들 -->

## 🚩 이슈 <!-- 해결하지 못한 내용 또는 부족한 점이 있어 추가 논의가 필요할 것 같은 부분에 대한 상세 설명 -->

## 🛠 피드백 반영 사항 <!-- 회의 또는 리뷰를 통해 발견하여 수정한 내역에 대한 설명-->
