### PR TITLE
feat: SM-192 유저 즐겨찾기목록 api 로직 작성

### DIFF
--- a/src/pages/MyPage/index.tsx
+++ b/src/pages/MyPage/index.tsx
@@ -8,13 +8,13 @@ import UserForm from '@domain/UserForm';
 import CocktailList from '@domain/CocktailList';
 import SectionDividerWithTitle from '@domain/SectionDividerWithTitle';
 import SearchBot from '@domain/SearchBot';
-import type { IApiResponse, IUser, IUserForm } from '@models';
+import type { IApiResponse, ICocktailSimple, IUser, IUserForm } from '@models';
 import useAxios from '@hooks/useAxios';
 import { AXIOS_REQUEST_TYPE } from '@constants/axios';
 import { useAuthorization } from '@contexts';
 import { Loader } from '@compound';
 import { Text } from '@base';
-import { getUserReducer, postUserReducer } from './reducer';
+import { getBookmarkReducer, getUserReducer, postUserReducer } from './reducer';
 
 const TEN_RADIX = 10;
 
@@ -35,6 +35,10 @@ const MyPage = (): ReactElement => {
     postUserReducer,
     { value: null, isLoading: false, error: null }
   );
+  const [getBookmarkAPIState, dispatchGetBookmarkAPIState] = useReducer(
+    getBookmarkReducer,
+    { value: null, isLoading: false, error: null }
+  );
   // api
   const getUserProfile = (userId: number): Promise<IApiResponse<IUser>> =>
     request.get(`/user/${userId}`);
@@ -47,6 +51,10 @@ const MyPage = (): ReactElement => {
       mbti
     });
   };
+  const getUserBookmarks = (
+    userId: number
+  ): Promise<IApiResponse<ICocktailSimple[]>> =>
+    request.get(`user/bookmark/${userId}`);
 
   const getUser = async (userId: number): Promise<void> => {
     try {
@@ -81,6 +89,26 @@ const MyPage = (): ReactElement => {
       dispatchPostUserAPIState({ type: 'API_END' });
     }
   };
+  const getBookmarkByUserId = async (userId: number): Promise<void> => {
+    try {
+      dispatchGetBookmarkAPIState({ type: 'API_START' });
+      const { data } = await getUserBookmarks(userId);
+      if (data) {
+        dispatchGetBookmarkAPIState({
+          type: 'API_SUCCESS',
+          payload: data
+        });
+      }
+    } catch (e) {
+      dispatchGetBookmarkAPIState({
+        type: 'API_FAILED'
+      });
+    } finally {
+      dispatchGetBookmarkAPIState({
+        type: 'API_END'
+      });
+    }
+  };
 
   const handleEditUserSubmit = (userForm: IUserForm): void => {
     postUser(userForm);
@@ -93,14 +121,12 @@ const MyPage = (): ReactElement => {
   useEffect(() => {
     if (user) {
       getUser(user.id);
+      getBookmarkByUserId(user.id);
     } else {
       console.error('유저 정보가 없습니다!');
       navigate(-1);
     }
   }, []);
-
-  // 칵테일 임시정보
-  const cocktails: any[] = [];
 
   return (
     <>
@@ -125,7 +151,15 @@ const MyPage = (): ReactElement => {
           />
         </Carousel.Container>
         {selectedIndex === 0 ? (
-          <CocktailList cocktailList={cocktails} />
+          getBookmarkAPIState.isLoading ? (
+            <Loader />
+          ) : getBookmarkAPIState.value ? (
+            <CocktailList cocktailList={getBookmarkAPIState.value} />
+          ) : (
+            <Text color='LIGHT_GRAY' size='sm'>
+              Cocktail 정보를 받아올수 없습니다
+            </Text>
+          )
         ) : getUserAPIState.isLoading ? (
           <Loader />
         ) : getUserAPIState.value ? (
@@ -135,7 +169,9 @@ const MyPage = (): ReactElement => {
             onSubmit={handleEditUserSubmit}
           />
         ) : (
-          <Text>User 정보를 받아올수 없습니다</Text>
+          <Text color='LIGHT_GRAY' size='sm'>
+            User 정보를 받아올수 없습니다
+          </Text>
         )}
         {postUserAPIState.value ? <Text>회원정보가 수정되었습니다!</Text> : ''}
       </SectionDividerWithTitle>

--- a/src/pages/MyPage/reducer.ts
+++ b/src/pages/MyPage/reducer.ts
@@ -1,26 +1,11 @@
-import type { IUserForm } from '@models';
-
-interface PostUserState {
-  value: string | null;
-  isLoading: boolean;
-  error: any;
-}
-type PostUserAction =
-  | { type: 'API_START' }
-  | { type: 'API_SUCCESS'; payload: string }
-  | { type: 'API_FAILED'; payload: any }
-  | { type: 'API_END' };
-
-interface GetUserState {
-  value: IUserForm | null;
-  isLoading: boolean;
-  error: any;
-}
-type GetUserAction =
-  | { type: 'API_START' }
-  | { type: 'API_SUCCESS'; payload: IUserForm }
-  | { type: 'API_FAILED'; payload: any }
-  | { type: 'API_END' };
+import type {
+  GetBookmarkAction,
+  GetBookmarkState,
+  GetUserAction,
+  GetUserState,
+  PostUserAction,
+  PostUserState
+} from './types';
 
 const postUserReducer = (
   state: PostUserState,
@@ -54,4 +39,20 @@ const getUserReducer = (
   }
 };
 
-export { postUserReducer, getUserReducer };
+const getBookmarkReducer = (
+  state: GetBookmarkState,
+  action: GetBookmarkAction
+): GetBookmarkState => {
+  switch (action.type) {
+    case 'API_START':
+      return { value: null, isLoading: true, error: null };
+    case 'API_SUCCESS':
+      return { ...state, value: action.payload };
+    case 'API_FAILED':
+      return { ...state, value: [] };
+    case 'API_END':
+      return { ...state, isLoading: false };
+  }
+};
+
+export { postUserReducer, getUserReducer, getBookmarkReducer };

--- a/src/pages/MyPage/types.ts
+++ b/src/pages/MyPage/types.ts
@@ -1,0 +1,43 @@
+import type { ICocktailSimple, IUserForm } from '@models';
+
+interface PostUserState {
+  value: string | null;
+  isLoading: boolean;
+  error: any;
+}
+type PostUserAction =
+  | { type: 'API_START' }
+  | { type: 'API_SUCCESS'; payload: string }
+  | { type: 'API_FAILED'; payload: any }
+  | { type: 'API_END' };
+
+interface GetUserState {
+  value: IUserForm | null;
+  isLoading: boolean;
+  error: any;
+}
+type GetUserAction =
+  | { type: 'API_START' }
+  | { type: 'API_SUCCESS'; payload: IUserForm }
+  | { type: 'API_FAILED'; payload: any }
+  | { type: 'API_END' };
+
+interface GetBookmarkState {
+  value: ICocktailSimple[] | null;
+  isLoading: boolean;
+  error: any;
+}
+type GetBookmarkAction =
+  | { type: 'API_START' }
+  | { type: 'API_SUCCESS'; payload: ICocktailSimple[] }
+  | { type: 'API_FAILED' }
+  | { type: 'API_END' };
+
+export type {
+  PostUserState,
+  PostUserAction,
+  GetUserAction,
+  GetUserState,
+  GetBookmarkState,
+  GetBookmarkAction
+};


### PR DESCRIPTION
## 📌 내용 설명 <!-- 구현한 내용의 핵심 요약 -->
유저 즐겨찾기목록 api 로직 작성하였습니다.
## 👀 이미지 또는 Gif <!-- 구현한 내용의 동작을 담은 이미지, gif 등. 시각화된 내용이 없다면 생략 -->
![화면 기록 2021-12-18 오후 6 17 44](https://user-images.githubusercontent.com/75013334/146636150-93131d58-89f7-45c4-b1ad-cd3684297a70.gif)

## 📝 요구 사항 <!-- 구현한 내용의 세부 사항 목록과 완료 여부 체크 -->
- 마이페이이지에 접근시, Context에 user객체가 존재한다면 api호출을 진행합니다. 진행로직은 회원정보 수정과 동일합니다.
## 💡 포인트 <!-- 구현한 내용 중 추가 설명, 강조가 필요한 핵심 로직이나 코드 설명. '특히 자세히 봐줬으면 좋겠다!'하는 내용들 -->
- useReducer를 이용하여 로직 구현하였습니다.
## 🚩 이슈 <!-- 해결하지 못한 내용 또는 부족한 점이 있어 추가 논의가 필요할 것 같은 부분에 대한 상세 설명 -->
- api 로직을 useReducer로 구현할때, 중복되는 코드 및 규칙성들이 보입니다. useAPI와 같은 hooks를 작성하여 중복되는 코드들을 줄일수 있을것같습니다.
## 🛠 피드백 반영 사항 <!-- 회의 또는 리뷰를 통해 발견하여 수정한 내역에 대한 설명-->
