### PR TITLE
feat: SM-195 CustomNavigate context 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,13 @@
 import AuthorizationProvider from '@contexts/Authorization';
+import { CustomNavigateProvider } from '@contexts/CustomNavigate';
 import { Router } from '@routes';
 
 function App(): JSX.Element {
   return (
     <AuthorizationProvider>
-      <Router />
+      <CustomNavigateProvider>
+        <Router />
+      </CustomNavigateProvider>
     </AuthorizationProvider>
   );
 }

--- a/src/components/domain/Header/index.tsx
+++ b/src/components/domain/Header/index.tsx
@@ -8,16 +8,18 @@ import themeImageSrc from '@assets/headerIcon/to_theme.png';
 import profileImageSrc from '@assets/headerIcon/to_profile.png';
 import ImageButton from '@compound/ImageButton';
 import { useAuthorization } from '@contexts';
-import { useLocation, useNavigate } from 'react-router';
+import { useLocation } from 'react-router';
 import { getDomain } from '@utils/lib/getDomain';
 import { DOMAINS } from '@constants';
 import { Tooltip } from '@base';
+import { useCustomNavigate } from '@contexts/CustomNavigate';
 
 const Header = (): ReactElement => {
   const { oauthToken, user } = useAuthorization();
+  const { navigate, saveCurrentPath } = useCustomNavigate();
   const location = useLocation();
+
   const domain = useMemo(() => getDomain(location.pathname), [location]);
-  const navigate = useNavigate();
   const handleLink = useCallback(
     (to: string): void => {
       navigate(to);
@@ -77,6 +79,7 @@ const Header = (): ReactElement => {
           size='headerIcon'
           src={loginImageSrc}
           onClick={(): void => {
+            saveCurrentPath();
             handleLink(`/${DOMAINS.login}`);
           }}
         />

--- a/src/components/domain/KaKaoButton/index.tsx
+++ b/src/components/domain/KaKaoButton/index.tsx
@@ -1,6 +1,8 @@
 import ImageButton from '@compound/ImageButton';
 import type { ReactElement } from 'react';
 import kakaoSrc from '@assets/oauthAssets/kakao_login.png';
+import { useCustomNavigate } from '@contexts/CustomNavigate';
+import type { KaKaoButtonProps } from './types';
 // import { useNavigate } from 'react-router';
 // import { DOMAINS } from '@constants';
 const { REACT_APP_BASE_URL: BASE_URL } = process.env;
@@ -9,12 +11,13 @@ const { REACT_APP_BASE_URL: BASE_URL } = process.env;
 // const REDIRECT_URI = `${BASE_URL}/login/oauth2/code/kakao`;
 // const REDIRECT_URI = `${BASE_URL}/login`;
 
-const KaKaoButton = (): ReactElement => {
+const KaKaoButton = ({ redirectUrl }: KaKaoButtonProps): ReactElement => {
+  const { savePath } = useCustomNavigate();
   const handleLogin = (): void => {
-    console.log('login!');
     // window.location.assign(
     //   `https://kauth.kakao.com/oauth/authorize?client_id=${CLIENT_ID}&redirect_uri=${REDIRECT_URI}&response_type=code&state=alchomist`
     // );
+    redirectUrl && savePath(redirectUrl);
     window.location.assign(`${BASE_URL}/login`);
   };
 

--- a/src/components/domain/KaKaoButton/types.ts
+++ b/src/components/domain/KaKaoButton/types.ts
@@ -1,0 +1,5 @@
+interface KaKaoButtonProps {
+  redirectUrl?: string;
+}
+
+export type { KaKaoButtonProps };

--- a/src/contexts/Authorization/index.tsx
+++ b/src/contexts/Authorization/index.tsx
@@ -60,7 +60,7 @@ const AuthorizationProvider = ({
 }: {
   children: ReactNode;
 }): ReactElement => {
-  const [state, setState] = useSessionStorage<IAuthState>('auth', {
+  const [state, setState, clearState] = useSessionStorage<IAuthState>('auth', {
     oauthToken: null,
     user: null,
     isAuthorized: false
@@ -74,7 +74,7 @@ const AuthorizationProvider = ({
   };
 
   const logout = (): void => {
-    setState({ oauthToken: null, user: null, isAuthorized: false });
+    clearState();
   };
 
   const setOAuthToken = (oauthToken: string): void => {

--- a/src/contexts/CustomNavigate/index.tsx
+++ b/src/contexts/CustomNavigate/index.tsx
@@ -1,0 +1,57 @@
+import useSessionStorage from '@hooks/useSessionStorage';
+import type { ReactChild, ReactElement } from 'react';
+import { useContext, createContext } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import type { INavigateContext } from './types';
+
+const RedirectPathContext = createContext<INavigateContext | null>(null);
+
+const useCustomNavigate = (): INavigateContext => {
+  const context = useContext(RedirectPathContext);
+  if (!context) {
+    throw new Error('there is no Context!');
+  }
+
+  return context;
+};
+
+const CustomNavigateProvider = ({
+  children
+}: {
+  children: ReactChild | ReactChild[];
+}): ReactElement => {
+  const [redirectPath, setRedirectPath, clearRedirectPath] = useSessionStorage<
+    string | null
+  >('path', null);
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  const saveCurrentPath = (): void => {
+    setRedirectPath(location.pathname);
+  };
+  const savePath = (pathname: string): void => {
+    setRedirectPath(pathname);
+  };
+
+  const redirectToSavedPath = (): void => {
+    redirectPath && navigate(redirectPath);
+    clearRedirectPath();
+  };
+
+  return (
+    <RedirectPathContext.Provider
+      value={{
+        redirectPath,
+        navigate,
+        saveCurrentPath,
+        savePath,
+        clearRedirectPath,
+        redirectToSavedPath
+      }}
+    >
+      {children}
+    </RedirectPathContext.Provider>
+  );
+};
+
+export { useCustomNavigate, CustomNavigateProvider };

--- a/src/contexts/CustomNavigate/types.ts
+++ b/src/contexts/CustomNavigate/types.ts
@@ -1,0 +1,12 @@
+import type { NavigateFunction } from 'react-router-dom';
+
+interface INavigateContext {
+  navigate: NavigateFunction;
+  redirectPath?: string | null;
+  saveCurrentPath(): void;
+  savePath(pathname: string): void;
+  clearRedirectPath(): void;
+  redirectToSavedPath(): void;
+}
+
+export type { INavigateContext };

--- a/src/hooks/useSessionStorage.ts
+++ b/src/hooks/useSessionStorage.ts
@@ -3,7 +3,7 @@ import { useState } from 'react';
 const useSessionStorage = <T>(
   key: string,
   initialValue: T
-): [T, (value: T) => void] => {
+): [T, (value: T) => void, () => void] => {
   const [storedValue, setStoredValue] = useState<T>(() => {
     try {
       const item = sessionStorage.getItem(key);
@@ -26,7 +26,16 @@ const useSessionStorage = <T>(
     }
   };
 
-  return [storedValue, setValue];
+  const clearValue = (): void => {
+    try {
+      setStoredValue(initialValue);
+      sessionStorage.removeItem(key);
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
+  return [storedValue, setValue, clearValue];
 };
 
 export default useSessionStorage;

--- a/src/pages/LoginPage/index.tsx
+++ b/src/pages/LoginPage/index.tsx
@@ -3,12 +3,22 @@ import BackButton from '@domain/BackButton';
 import KaKaoButton from '@domain/KaKaoButton';
 import TitleSectionContainer from '@domain/TitleSectionContainer';
 import type { ReactElement } from 'react';
+import { useCallback } from 'react';
 import BartenderSrc from '@assets/characters/searchBartender.png';
-import { useNavigate } from 'react-router';
 import { StyledPageContainerWithBackground } from '@base/PageContainerWithBackground/styled';
+import { useCustomNavigate } from '@contexts/CustomNavigate';
+import { DOMAINS } from '@constants';
 
 const LoginPage = (): ReactElement => {
-  const navigate = useNavigate();
+  const { navigate, redirectPath, redirectToSavedPath } = useCustomNavigate();
+
+  const handleBack = useCallback(() => {
+    if (redirectPath) {
+      redirectToSavedPath();
+    } else {
+      navigate(`/${DOMAINS.main}`);
+    }
+  }, [redirectPath, redirectToSavedPath]);
 
   return (
     <StyledPageContainerWithBackground>
@@ -39,12 +49,7 @@ const LoginPage = (): ReactElement => {
           </TitleSectionContainer>
         </div>
       </Modal>
-      <BackButton
-        color='NAVY'
-        onClick={(): void => {
-          navigate(-1);
-        }}
-      />
+      <BackButton color='NAVY' onClick={handleBack} />
     </StyledPageContainerWithBackground>
   );
 };

--- a/src/pages/MainPage/index.tsx
+++ b/src/pages/MainPage/index.tsx
@@ -77,7 +77,7 @@ const MainPage = (): ReactElement => {
             추천받으러 가기
           </TextButton>
         ) : (
-          <KaKaoButton />
+          <KaKaoButton redirectUrl={`/${DOMAINS.jango}`} />
         )}
       </StyledDescriptionContainer>
     </StyledPageContainer>

--- a/src/pages/MyPage/index.tsx
+++ b/src/pages/MyPage/index.tsx
@@ -16,6 +16,7 @@ import { Loader } from '@compound';
 import { Text } from '@base';
 import { getBookmarkReducer, getUserReducer, postUserReducer } from './reducer';
 import { StyledLogoutButton } from './styled';
+import { DOMAINS } from '@constants';
 
 const TEN_RADIX = 10;
 
@@ -181,7 +182,7 @@ const MyPage = (): ReactElement => {
         buttonType='SHORT_PINK'
         onClick={(): void => {
           logout();
-          navigate('/');
+          navigate(`/${DOMAINS.main}`);
         }}
       >
         로그 아웃

--- a/src/pages/OAuthKaKaoPage/index.tsx
+++ b/src/pages/OAuthKaKaoPage/index.tsx
@@ -1,21 +1,23 @@
 // import { request } from '@apis/config';
 import { StyledPageContainerWithBackground } from '@base/PageContainerWithBackground/styled';
 import { Loader } from '@compound';
+import { DOMAINS } from '@constants';
 import { AXIOS_REQUEST_TYPE } from '@constants/axios';
 import { useAuthorization } from '@contexts';
+import { useCustomNavigate } from '@contexts/CustomNavigate';
 import useAxios from '@hooks/useAxios';
 import type { IApiResponse, IUser } from '@models';
 import type { ReactElement } from 'react';
 import { useEffect } from 'react';
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router-dom';
 import { StyledLoaderContainer } from './styled';
 
 // const POST_AUTHORIZED_CODE_URL = '';
 
 const OAuthKaKaoPage = (): ReactElement => {
   const [searchParams, setSearchParams] = useSearchParams();
-  const navigate = useNavigate();
   const { setOAuthToken, login } = useAuthorization();
+  const { navigate, redirectToSavedPath, redirectPath } = useCustomNavigate();
   const request = useAxios(AXIOS_REQUEST_TYPE.AUTH);
   const token = searchParams.get('token');
   const needInfo = searchParams.get('needInfo');
@@ -28,16 +30,21 @@ const OAuthKaKaoPage = (): ReactElement => {
     const handleLogin = async (token: string): Promise<void> => {
       const { data } = await getUser(token);
       login({ oauthToken: token, user: data });
-      // 임시 위치 ( 이후 useRedirectURL Context로 위치 기억하여 이동 예정)
-      navigate('/jango');
+      if (redirectPath) {
+        redirectToSavedPath();
+      } else {
+        navigate(`/${DOMAINS.main}`);
+      }
     };
 
     if (token) {
       setOAuthToken(token);
       setSearchParams({}, { replace: true });
-      needInfo === 'true' ? navigate('/register') : handleLogin(token); // 로그인시에는 별도
+      needInfo === 'true'
+        ? navigate(`/${DOMAINS.register}`)
+        : handleLogin(token); // 로그인시에는 별도
     } else {
-      navigate('/');
+      navigate(`/${DOMAINS.main}`);
     }
   }, []);
 

--- a/src/pages/RegisterPage/index.tsx
+++ b/src/pages/RegisterPage/index.tsx
@@ -1,20 +1,21 @@
 import { StyledPageContainerWithBackground } from '@base/PageContainerWithBackground/styled';
+import { DOMAINS } from '@constants';
 import { AXIOS_REQUEST_TYPE } from '@constants/axios';
 import { useAuthorization } from '@contexts';
+import { useCustomNavigate } from '@contexts/CustomNavigate';
 import BackButton from '@domain/BackButton';
 import RegisterModal from '@domain/RegisterModal';
 import useAxios from '@hooks/useAxios';
 import type { IApiResponse, IUser, IUserForm } from '@models';
 import type { ReactElement } from 'react';
-import { useNavigate } from 'react-router';
 import type { IRegisterRequestBody } from './types';
 
 // test email
 
 const RegisterPage = (): ReactElement => {
-  const navigate = useNavigate();
   const request = useAxios(AXIOS_REQUEST_TYPE.AUTH);
   const { oauthToken, login, logout } = useAuthorization();
+  const { navigate, redirectToSavedPath, redirectPath } = useCustomNavigate();
 
   const postRegister = (
     data: IRegisterRequestBody
@@ -33,12 +34,12 @@ const RegisterPage = (): ReactElement => {
       });
       if (data) {
         login({ oauthToken, user: data });
-        // 임시 위치 ( 이후 useRedirectURL Context로 지정된 위치로 이동 예정)
-        navigate('/');
+
+        redirectPath ? redirectToSavedPath() : navigate(`/${DOMAINS.main}`);
       } else {
         alert('회원가입에 실패하였습니다. 이후에 다시한번 시도해주세요.');
         logout();
-        navigate('/');
+        navigate(`/${DOMAINS.main}`);
       }
     }
   };


### PR DESCRIPTION
## 📌 내용 설명 <!-- 구현한 내용의 핵심 요약 -->
redirectpath를 저장하고, 해당 path로 navigate시켜줄수있는 customnavigate를 구현하였습니다.
## 👀 이미지 또는 Gif <!-- 구현한 내용의 동작을 담은 이미지, gif 등. 시각화된 내용이 없다면 생략 -->

## 📝 요구 사항 <!-- 구현한 내용의 세부 사항 목록과 완료 여부 체크 -->

## 💡 포인트 <!-- 구현한 내용 중 추가 설명, 강조가 필요한 핵심 로직이나 코드 설명. '특히 자세히 봐줬으면 좋겠다!'하는 내용들 -->
useSessionStorage를 이용하여 redirectpath를 sessionStorage에서도 별도로 저장합니다.
OAuth를 위해 페이지에서 벗어나거나 새로고침을 하여도 redirectpath 경로를 기억하도록 하였습니다.

해당 CustomNavigate를 사용하여 로그인시 redirect 위치를 기억시켜 이동할수 있도록 적용하였습니다.
## 🚩 이슈 <!-- 해결하지 못한 내용 또는 부족한 점이 있어 추가 논의가 필요할 것 같은 부분에 대한 상세 설명 -->

## 🛠 피드백 반영 사항 <!-- 회의 또는 리뷰를 통해 발견하여 수정한 내역에 대한 설명-->
