### PR TITLE
feat: SM-197 새창으로 로그인 기능

### DIFF
--- a/src/components/domain/KaKaoButton/index.tsx
+++ b/src/components/domain/KaKaoButton/index.tsx
@@ -3,6 +3,7 @@ import type { ReactElement } from 'react';
 import kakaoSrc from '@assets/oauthAssets/kakao_login.png';
 import { useCustomNavigate } from '@contexts/CustomNavigate';
 import type { KaKaoButtonProps } from './types';
+import { DOMAINS } from '@constants';
 // import { useNavigate } from 'react-router';
 // import { DOMAINS } from '@constants';
 const { REACT_APP_BASE_URL: BASE_URL } = process.env;
@@ -12,13 +13,19 @@ const { REACT_APP_BASE_URL: BASE_URL } = process.env;
 // const REDIRECT_URI = `${BASE_URL}/login`;
 
 const KaKaoButton = ({ redirectUrl }: KaKaoButtonProps): ReactElement => {
-  const { savePath } = useCustomNavigate();
+  const { savePath, navigate } = useCustomNavigate();
   const handleLogin = (): void => {
     // window.location.assign(
     //   `https://kauth.kakao.com/oauth/authorize?client_id=${CLIENT_ID}&redirect_uri=${REDIRECT_URI}&response_type=code&state=alchomist`
     // );
     redirectUrl && savePath(redirectUrl);
-    window.location.assign(`${BASE_URL}/login`);
+    window.open(
+      `${BASE_URL}/login`,
+      '__blank',
+      'fullscreen=no, width=500, height=600, resizable=no'
+    );
+    navigate(`/${DOMAINS.oauthKaKao}?loading=true`);
+    // window.location.assign(`${BASE_URL}/login`);
   };
 
   return (

--- a/src/pages/OAuthKaKaoPage/styled.ts
+++ b/src/pages/OAuthKaKaoPage/styled.ts
@@ -6,6 +6,7 @@ const StyledLoaderContainer = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
+  flex-direction: column;
 `;
 
 export { StyledLoaderContainer };


### PR DESCRIPTION
## 📌 내용 설명 <!-- 구현한 내용의 핵심 요약 -->
백엔드 쪽으로 보내는 url을 새창으로 띄우는 방식으로 바꾸었습니다.
## 👀 이미지 또는 Gif <!-- 구현한 내용의 동작을 담은 이미지, gif 등. 시각화된 내용이 없다면 생략 -->
![화면 기록 2021-12-19 오전 3 34 59](https://user-images.githubusercontent.com/75013334/146652253-6ddf24cd-0576-4c6a-a5c8-399d8a4ca151.gif)

## 📝 요구 사항 <!-- 구현한 내용의 세부 사항 목록과 완료 여부 체크 -->
- 현재 백엔드 측의 OAuth 로그인 로직구현에 문제가 있어, 백엔드 서버에 접속하여 유저가 버튼을 클릭해야하는 상황입니다.
- 해당 모습을 덜 어색하게 보이기 위해, 해당 페이지를 새창으로 띄우고, localStorage를 통해 두 창이 데이터를 공유하는 형태로 로직을 수정하였습니다.
- 기존의 페이지는 setInterval을 통해 localStorage의 'temp' 키로 값을 받습니다.
## 💡 포인트 <!-- 구현한 내용 중 추가 설명, 강조가 필요한 핵심 로직이나 코드 설명. '특히 자세히 봐줬으면 좋겠다!'하는 내용들 -->

## 🚩 이슈 <!-- 해결하지 못한 내용 또는 부족한 점이 있어 추가 논의가 필요할 것 같은 부분에 대한 상세 설명 -->

## 🛠 피드백 반영 사항 <!-- 회의 또는 리뷰를 통해 발견하여 수정한 내역에 대한 설명-->
