### PR TITLE
fix: SM-202 private route login페이지 이동 replace로 변경

### DIFF
--- a/src/routes/PrivateRoutes/index.tsx
+++ b/src/routes/PrivateRoutes/index.tsx
@@ -5,7 +5,11 @@ import { useAuthorization } from '@contexts/Authorization';
 
 const PrivateRoutes = ({ children }: RoutesProps): ReactElement => {
   const { isAuthorized } = useAuthorization();
-  return isAuthorized ? <Routes>{children}</Routes> : <Navigate to='/login' />;
+  return isAuthorized ? (
+    <Routes>{children}</Routes>
+  ) : (
+    <Navigate replace to='/login' />
+  );
 };
 
 export default PrivateRoutes;


### PR DESCRIPTION
## 📌 내용 설명 <!-- 구현한 내용의 핵심 요약 -->
private route login페이지 이동 replace로 변경하였습니다.
## 👀 이미지 또는 Gif <!-- 구현한 내용의 동작을 담은 이미지, gif 등. 시각화된 내용이 없다면 생략 -->

## 📝 요구 사항 <!-- 구현한 내용의 세부 사항 목록과 완료 여부 체크 -->
기존대로 replace가 아닌 push로 이루어지면, 이전 페이지로 계속 이동하도록 시도하게됩니다. 이전페이지는 로그인이 필요한 페이지므로, 결국 다시 login 페이지로 redirect가 되는 상황입니다.
replace를 통해 이전 페이지의 state를 덮어씌웁니다.
## 💡 포인트 <!-- 구현한 내용 중 추가 설명, 강조가 필요한 핵심 로직이나 코드 설명. '특히 자세히 봐줬으면 좋겠다!'하는 내용들 -->

## 🚩 이슈 <!-- 해결하지 못한 내용 또는 부족한 점이 있어 추가 논의가 필요할 것 같은 부분에 대한 상세 설명 -->

## 🛠 피드백 반영 사항 <!-- 회의 또는 리뷰를 통해 발견하여 수정한 내역에 대한 설명-->
