### PR TITLE
fix: SM-212 bookmark null bug 수정

### DIFF
--- a/src/components/domain/CocktailDetailModal/index.tsx
+++ b/src/components/domain/CocktailDetailModal/index.tsx
@@ -116,7 +116,7 @@ const CocktailDetailModal = ({
                 tooltipSize='xs'
               >
                 <IconToggle
-                  initialState={user?.bookmarks.some(
+                  initialState={user?.bookmarks?.some(
                     (cocktail) => cocktail.id === cocktailId
                   )}
                   name='flag'

--- a/src/contexts/Authorization/index.tsx
+++ b/src/contexts/Authorization/index.tsx
@@ -28,7 +28,16 @@ const AuthorizationProvider = ({
     oauthToken,
     user
   }: Omit<IAuthState, 'isAuthorized'>): void => {
-    setState({ oauthToken, user, isAuthorized: true });
+    if (oauthToken && user) {
+      setState({
+        oauthToken,
+        user: {
+          ...user,
+          bookmarks: user?.bookmarks || []
+        },
+        isAuthorized: true
+      });
+    }
   };
 
   const logout = (): void => {


### PR DESCRIPTION
## 📌 내용 설명 <!-- 구현한 내용의 핵심 요약 -->
최초 회원가입후 jango 페이지 진입시에 유저 bookmark 값이 null인 문제로 에러가 발생하는 문제를 수정하였습니다.
## 👀 이미지 또는 Gif <!-- 구현한 내용의 동작을 담은 이미지, gif 등. 시각화된 내용이 없다면 생략 -->

## 📝 요구 사항 <!-- 구현한 내용의 세부 사항 목록과 완료 여부 체크 -->
login 시에 bookmark 가 없다면, 빈배열로 초기화 함으로써 
detailModal에서 user.bookmark.some 메소드가 에러없이 일어날수있도록 수정하였습니다.
## 💡 포인트 <!-- 구현한 내용 중 추가 설명, 강조가 필요한 핵심 로직이나 코드 설명. '특히 자세히 봐줬으면 좋겠다!'하는 내용들 -->

## 🚩 이슈 <!-- 해결하지 못한 내용 또는 부족한 점이 있어 추가 논의가 필요할 것 같은 부분에 대한 상세 설명 -->

## 🛠 피드백 반영 사항 <!-- 회의 또는 리뷰를 통해 발견하여 수정한 내역에 대한 설명-->
