### PR TITLE
fix: SM-213 register 페이지에서 최초 initialValidate 제거

### DIFF
--- a/src/components/domain/UserForm/index.tsx
+++ b/src/components/domain/UserForm/index.tsx
@@ -24,7 +24,7 @@ const UserForm = ({
     useForm<IUserForm>({
       initialValues,
       validateOnChange: true,
-      validateOnInitial: true,
+      validateOnInitial: type === 'EditProfile' ? true : false,
       onSubmit,
       validateFn: validateUser
     });


### PR DESCRIPTION
## 📌 내용 설명 <!-- 구현한 내용의 핵심 요약 -->
register 페이지에서 최초로 initialValidate를 진행하지 않도록 수정합니다.
## 👀 이미지 또는 Gif <!-- 구현한 내용의 동작을 담은 이미지, gif 등. 시각화된 내용이 없다면 생략 -->

## 📝 요구 사항 <!-- 구현한 내용의 세부 사항 목록과 완료 여부 체크 -->
1. userForm의 validateOnInitial를 type에 따라 true, false를 지정합니다.
## 💡 포인트 <!-- 구현한 내용 중 추가 설명, 강조가 필요한 핵심 로직이나 코드 설명. '특히 자세히 봐줬으면 좋겠다!'하는 내용들 -->

## 🚩 이슈 <!-- 해결하지 못한 내용 또는 부족한 점이 있어 추가 논의가 필요할 것 같은 부분에 대한 상세 설명 -->

## 🛠 피드백 반영 사항 <!-- 회의 또는 리뷰를 통해 발견하여 수정한 내역에 대한 설명-->
