### PR TITLE
refactor: SM-215 Album 컴포넌트 prop 컨벤션 수정

### DIFF
--- a/src/components/compound/Album/index.tsx
+++ b/src/components/compound/Album/index.tsx
@@ -14,14 +14,15 @@ const Album = ({
   type = DEFAULT_TYPE,
   text = DEFAULT_TEXT,
   imageSrc = DEFAULT_IMAGE_SRC,
-  handleAlbumClick
+  onHandleAlbumClick
 }: AlbumProps): ReactElement => {
-  const onhandleClick = (): void => {
-    handleAlbumClick?.(cocktailId ? cocktailId : 0);
-  };
-
   return (
-    <StyledContainer type={type} onClick={onhandleClick}>
+    <StyledContainer
+      type={type}
+      onClick={(): void => {
+        onHandleAlbumClick?.(cocktailId ? cocktailId : 0);
+      }}
+    >
       <Image
         height={ALBUM_ATTRIBUTES[type].imageHeight}
         mode='contain'

--- a/src/components/compound/Album/types.ts
+++ b/src/components/compound/Album/types.ts
@@ -35,7 +35,7 @@ interface AlbumProps extends HTMLAttributes<HTMLDivElement> {
   type?: AlbumAttributeKeys;
   text?: string;
   imageSrc?: string;
-  handleAlbumClick?(id: number): void;
+  onHandleAlbumClick?(id: number): void;
 }
 
 export type { AlbumProps, AlbumAttributeKeys };

--- a/src/components/domain/CocktailList/index.tsx
+++ b/src/components/domain/CocktailList/index.tsx
@@ -29,7 +29,6 @@ const CocktailList = ({
               <StyledMotionWrapper resultIndex={index}>
                 <Album
                   cocktailId={cocktail.id}
-                  handleAlbumClick={handleAlbumClick}
                   imageSrc={
                     CocktailIcons[
                       ((index + cocktail.id) %
@@ -38,6 +37,7 @@ const CocktailList = ({
                   }
                   text={cocktail.name}
                   type='result'
+                  onHandleAlbumClick={handleAlbumClick}
                 />
               </StyledMotionWrapper>
             ))


### PR DESCRIPTION
## 📌 내용 설명 <!-- 구현한 내용의 핵심 요약 -->
가독성을 높이기 위해 on0000 형식으로 prop명을 수정했습니다.

## 👀 이미지 또는 Gif <!-- 구현한 내용의 동작을 담은 이미지, gif 등. 시각화된 내용이 없다면 생략 -->

## 📝 요구 사항 <!-- 구현한 내용의 세부 사항 목록과 완료 여부 체크 -->
- [x] 코드의 가독성과 일관성 높이기

## 💡 포인트 <!-- 구현한 내용 중 추가 설명, 강조가 필요한 핵심 로직이나 코드 설명. '특히 자세히 봐줬으면 좋겠다!'하는 내용들 -->
상위컴포넌트에서 하위 컴포넌트로 함수를 내려줄 때, 이를 받는 하위컴포넌트에서 해당 prop을 정의 시에는 on0000 컨벤션을 준수하는 것이 어떻겠냐는 사휘님의 코멘트를 반영하여, 기존의 `handleAlbumClick` 을 `onHandleAlbumClick`으로 변경하였고, Album 컴포넌트 내의 `onhandleClick` 함수는 컴포넌트 내에서 일회적으로 사용되고, wrapper 함수에 불과하기에, 별도의 함수명으로 분리하기 보다는 익명함수로 바인딩하는 것으로 수정했습니다.

## 🚩 이슈 <!-- 해결하지 못한 내용 또는 부족한 점이 있어 추가 논의가 필요할 것 같은 부분에 대한 상세 설명 -->

## 🛠 피드백 반영 사항 <!-- 회의 또는 리뷰를 통해 발견하여 수정한 내역에 대한 설명-->
